### PR TITLE
[WIP] Script to monitor web resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "hubot-shipit": "^0.2.0",
     "hubot-url-title": "^1.2.2",
     "hubot-wikipedia": "0.0.2",
-    "optparse": "1.0.3"
+    "optparse": "1.0.3",
+    "request": "^2.69.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "mocha --compilers coffee:coffee-script/register tests"
   },
   "dependencies": {
+    "crypto": "0.0.3",
     "hubot": ">= 2.6.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.2.4",

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -1,0 +1,48 @@
+# Description:
+#   Monitors modifications of web resources.
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   hubot watch http[s]://[url] - Adds a web resource to the list of monitored resources.
+#   hubot stop watching http[s]://[url] - Removes a web resource from the list.
+#   hubot what are you watching? - Returns the list of web resources to monitor.
+#
+# Author:
+#   Paul Chaignon <paul.chaignon@gmail.com>
+
+crypto = require "crypto"
+
+computeHash = (body) ->
+    return crypto.createHash("sha256").update(body).digest("base64")
+
+module.exports = (robot) ->
+  robot.respond /watch (https?:\/\/[^\s]+)$/, (res) ->
+    resource = res.match[1]
+    robot.http(resource).get() (err, response, body) ->
+      if err
+        res.reply "Are you sure about that url?"
+        res.send "#{err}"
+      else
+        hash = computeHash(body)
+        resources = robot.brain.get('web_resources') or []
+        resources.push(res.match[1])
+        robot.brain.set 'web_resources', resources
+        robot.brain.set "web_resources:#{resource}", hash
+        res.reply "Resource looks good. I'll keep you informed."
+
+  robot.respond /stop watching (https?:\/\/[^\s]+)$/, (res) ->
+    resources = robot.brain.get('web_resources') or []
+    if res.match[1] in resources
+      resources = resources.filter (resource) -> resource isnt res.match[1]
+      robot.brain.set 'web_resources', resources
+      res.reply "Less work? Aww..."
+    else
+      res.reply "I'm not :/"
+
+  robot.respond /what are you watching?/, (res) ->
+    res.reply robot.brain.get('web_resources')

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -100,8 +100,15 @@ module.exports = (robot) ->
       res.reply "I'm not :/"
 
   robot.respond /what are you watching?/, (res) ->
-    resources = Object.keys(robot.brain.get('web_resources')) or []
-    res.reply resources.join(', ')
+    resources = robot.brain.get('web_resources')
+    if resources is null
+      res.reply "Nothing :'("
+    else
+      resources = Object.keys(resources)
+      if resources is 0
+        res.reply "Nothing :'("
+      else
+        res.reply resources.join(', ')
 
   robot.respond /did any web resource change?/, (res) ->
     changedWebResources(robot, res)

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -26,7 +26,10 @@ computeHash = (body) ->
 changedWebResources = (robot, res) ->
   resources = robot.brain.get('web_resources') or {}
   for resource, hash of resources
-    robot.http(resource).get() (err, response, body) ->
+    changedWebResource(robot, res, resource, hash)
+
+changedWebResource = (robot, res, resource, hash) ->
+  robot.http(resource).get() (err, response, body) ->
       newHash = null
       if err
         newHash = 0

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -16,6 +16,7 @@
 #   Paul Chaignon <paul.chaignon@gmail.com>
 
 crypto = require "crypto"
+request = require "request"
 
 PERIODIC_CHECKS_INTERVAL = 10000
 periodicCheckId = null
@@ -30,7 +31,7 @@ changedWebResources = (robot, room) ->
     changedWebResource(robot, room, resource, hash)
 
 changedWebResource = (robot, room, resource, hash) ->
-  robot.http(resource).get() (err, response, body) ->
+  request "http://#{resource}", (err, response, body) ->
       newHash = null
       if err
         newHash = 0
@@ -74,8 +75,8 @@ module.exports = (robot) ->
   robot.respond /watch ((?:https?:\/\/)?([^\s]+))$/, (res) ->
     resource = res.match[1]
     if not /^https?:\/\//.test(resource)
-      resource = "https://#{resource}"
-    robot.http(resource).get() (err, response, body) ->
+      resource = "http://#{resource}"
+    request resource, (err, response, body) ->
       if err
         res.reply "Are you sure about that url?"
         res.send "#{err}"

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -18,7 +18,7 @@
 crypto = require "crypto"
 
 computeHash = (body) ->
-    return crypto.createHash("sha256").update(body).digest("base64")
+  return crypto.createHash("sha256").update(body).digest("base64")
 
 module.exports = (robot) ->
   robot.respond /watch (https?:\/\/[^\s]+)$/, (res) ->
@@ -27,22 +27,24 @@ module.exports = (robot) ->
       if err
         res.reply "Are you sure about that url?"
         res.send "#{err}"
-      else
+      else if response.statusCode is 200
         hash = computeHash(body)
-        resources = robot.brain.get('web_resources') or []
-        resources.push(res.match[1])
+        resources = robot.brain.get('web_resources') or {}
+        resources[res.match[1]] = hash
         robot.brain.set 'web_resources', resources
-        robot.brain.set "web_resources:#{resource}", hash
         res.reply "Resource looks good. I'll keep you informed."
+      else
+        res.reply "The resource seems unavailable: #{response.statusMessage}"
 
   robot.respond /stop watching (https?:\/\/[^\s]+)$/, (res) ->
-    resources = robot.brain.get('web_resources') or []
-    if res.match[1] in resources
-      resources = resources.filter (resource) -> resource isnt res.match[1]
+    resources = robot.brain.get('web_resources') or {}
+    if res.match[1] of resources
+      delete resources[res.match[1]]
       robot.brain.set 'web_resources', resources
       res.reply "Less work? Aww..."
     else
       res.reply "I'm not :/"
 
   robot.respond /what are you watching?/, (res) ->
-    res.reply robot.brain.get('web_resources')
+    resources = Object.keys(robot.brain.get('web_resources')) or []
+    res.reply resources.join(', ')

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -17,8 +17,46 @@
 
 crypto = require "crypto"
 
+periodicCheckId = null
+firstPeriodicCheck = true
+
 computeHash = (body) ->
   return crypto.createHash("sha256").update(body).digest("base64")
+
+changedWebResources = (robot, res) ->
+  resources = robot.brain.get('web_resources') or {}
+  for resource, hash of resources
+    robot.http(resource).get() (err, response, body) ->
+      newHash = null
+      if err
+        newHash = 0
+      else if response.statusCode is 200
+        newHash = computeHash body
+        if newHash is hash
+          newHash = null
+      else
+        newHash = response.statusCode
+      if newHash isnt null
+        callbackChangedResource(robot, resource, newHash, res)
+
+callbackChangedResource = (robot, resource, newHash, res) ->
+  # There might be concurrent accesses to web_resources here.
+  # Need a way to prevent integrity issues.
+  resources = robot.brain.get('web_resources') or {}
+  resources[resource] = newHash
+  robot.brain.set 'web_resources', resources
+  res.send "#{resource} changed"
+
+periodicCheck = (robot, res) ->
+  if firstPeriodicCheck
+    firstPeriodicCheck = false
+  else
+    resources = robot.brain.get('web_resources')
+    if resources is null
+      clearInterval(periodicCheckId)
+      firstPeriodicCheck = true
+    else
+      changedWebResources(robot, res)
 
 module.exports = (robot) ->
   robot.respond /watch (https?:\/\/[^\s]+)$/, (res) ->
@@ -32,6 +70,8 @@ module.exports = (robot) ->
         resources = robot.brain.get('web_resources') or {}
         resources[res.match[1]] = hash
         robot.brain.set 'web_resources', resources
+        if firstPeriodicCheck
+          periodicCheckId = setInterval(periodicCheck, 10000, robot, res)
         res.reply "Resource looks good. I'll keep you informed."
       else
         res.reply "The resource seems unavailable: #{response.statusMessage}"
@@ -48,3 +88,6 @@ module.exports = (robot) ->
   robot.respond /what are you watching?/, (res) ->
     resources = Object.keys(robot.brain.get('web_resources')) or []
     res.reply resources.join(', ')
+
+  robot.respond /did any web resource change?/, (res) ->
+    changedWebResources(robot, res)

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -78,10 +78,12 @@ init = (robot) ->
   resources = robot.brain.get('web_resources')
   room = robot.brain.get('room_web_resources')
   if resources isnt null and room isnt null
-    setInterval(periodicCheck, PERIODIC_CHECKS_INTERVAL, robot, room)
+    periodicCheckId = setInterval(periodicCheck, PERIODIC_CHECKS_INTERVAL, robot, room)
 
 module.exports = (robot) ->
-  init(robot)
+  robot.brain.on 'loaded', (_) ->
+    if periodicCheckId is null
+      init(robot)
 
   robot.respond /watch ((?:https?:\/\/)?([^\s]+))$/, (res) ->
     resource = res.match[1]

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -48,6 +48,16 @@ describe 'watch-web-resources', ->
         ['hubot', "@bob https://github.com"]
       ]
 
+  context 'someone asks for the list of monitored web resources', ->
+    beforeEach ->
+      @room.user.say 'bob', 'hubot: what are you watching?'
+
+    it "answers that it's not watching anything", ->
+      expect(@room.messages).to.eql [
+        ['bob', 'hubot: what are you watching?']
+        ['hubot', "@bob Nothing :'("]
+      ]
+
   context 'pchaigno does not care for github.com anymore', ->
     beforeEach ->
       @room.robot.brain.set 'web_resources', {'https://github.com': ''}

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -6,6 +6,7 @@ co = require('co')
 expect = require('chai').expect
 
 describe 'watch-web-resources', ->
+  this.timeout(5000)
 
   beforeEach ->
     @room = helper.createRoom(httpd: false)
@@ -90,7 +91,7 @@ describe 'watch-web-resources', ->
       @room.robot.brain.set 'web_resources', {'github.com': '', 'twitter.com': ''}
       co =>
         yield @room.user.say 'pchaigno', 'hubot: did any web resource change?'
-        yield new Promise.delay(1000)
+        yield new Promise.delay(2000)
 
     it 'answers with the url of the changed resources', ->
       expect(@room.messages).to.eql [

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -21,6 +21,7 @@ describe 'watch-web-resources', ->
         ['hubot', "@pchaigno Resource looks good. I'll keep you informed."]
       ]
       expect(Object.keys(@room.robot.brain.get('web_resources'))).to.eql ['https://github.com']
+      expect(@room.robot.brain.get('room_web_resources')).to.eql 'room1'
 
   context 'pchaigno wants to monitor an inexistant web resource', ->
     beforeEach ->
@@ -66,7 +67,7 @@ describe 'watch-web-resources', ->
         yield @room.user.say 'pchaigno', 'hubot: did any web resource change?'
         yield new Promise.delay(1000)
 
-    it 'answers with the url of the resources which changed', ->
+    it 'answers with the url of the changed resources', ->
       expect(@room.messages).to.eql [
         ['pchaigno', 'hubot: did any web resource change?']
         ['hubot', "https://github.com changed"]

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -1,0 +1,60 @@
+Helper = require('hubot-test-helper')
+helper = new Helper('./../scripts/watch-web-resources.coffee')
+
+Promise = require('bluebird')
+co = require('co')
+expect = require('chai').expect
+
+describe 'watch-web-resources', ->
+  beforeEach ->
+    @room = helper.createRoom(httpd: false)
+
+  context 'pchaigno wants to monitor a new web resource', ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'pchaigno', 'hubot: watch https://github.com'
+        yield new Promise.delay(1000)
+
+    it 'saves the resource in memory after checking it', ->
+      expect(@room.messages).to.eql [
+        ['pchaigno', 'hubot: watch https://github.com']
+        ['hubot', "@pchaigno Resource looks good. I'll keep you informed."]
+      ]
+      expect(@room.robot.brain.get('web_resources')).to.eql ['https://github.com']
+
+  context 'pchaigno wants to monitor an inexistant web resource', ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'pchaigno', 'hubot: watch https://orangesummerofcode.com'
+        yield new Promise.delay(1000)
+
+    it 'returns the error message', ->
+      expect(@room.messages).to.eql [
+        ['pchaigno', 'hubot: watch https://orangesummerofcode.com']
+        ['hubot', "@pchaigno Are you sure about that url?"]
+        ['hubot', 'Error: getaddrinfo ENOTFOUND orangesummerofcode.com orangesummerofcode.com:443']
+      ]
+      expect(@room.robot.brain.get('web_resources')).to.eql null
+
+  context 'someone asks for the list of monitored web resources', ->
+    beforeEach ->
+      @room.robot.brain.set 'web_resources', ['https://github.com']
+      @room.user.say 'bob', 'hubot: what are you watching?'
+
+    it "answers with the list of monitored web resources", ->
+      expect(@room.messages).to.eql [
+        ['bob', 'hubot: what are you watching?']
+        ['hubot', "@bob https://github.com"]
+      ]
+
+  context 'pchaigno does not care for github.com anymore', ->
+    beforeEach ->
+      @room.robot.brain.set 'web_resources', ['https://github.com']
+      @room.user.say 'pchaigno', 'hubot: stop watching https://github.com'
+
+    it 'removes github.com from the web resources to monitor', ->
+      expect(@room.messages).to.eql [
+        ['pchaigno', 'hubot: stop watching https://github.com']
+        ['hubot', "@pchaigno Less work? Aww..."]
+      ]
+      expect(@room.robot.brain.get('web_resources')).to.eql []

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -58,3 +58,28 @@ describe 'watch-web-resources', ->
         ['hubot', "@pchaigno Less work? Aww..."]
       ]
       expect(@room.robot.brain.get('web_resources')).to.eql {}
+
+  context 'pchaigno asks if any web resource changed', ->
+    beforeEach ->
+      @room.robot.brain.set 'web_resources', {'https://github.com': ''}
+      co =>
+        yield @room.user.say 'pchaigno', 'hubot: did any web resource change?'
+        yield new Promise.delay(1000)
+
+    it 'answers that github.com did change', ->
+      expect(@room.messages).to.eql [
+        ['pchaigno', 'hubot: did any web resource change?']
+        ['hubot', "https://github.com changed"]
+      ]
+      expect(@room.robot.brain.get('web_resources')['https://github.com']).to.not.eql ''
+
+  context 'pchaigno asks if any web resource changed', ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'pchaigno', 'hubot: did any web resource change?'
+        yield new Promise.delay(1000)
+
+    it 'answers that nothing changed', ->
+      expect(@room.messages).to.eql [
+        ['pchaigno', 'hubot: did any web resource change?']
+      ]

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -6,6 +6,7 @@ co = require('co')
 expect = require('chai').expect
 
 describe 'watch-web-resources', ->
+
   beforeEach ->
     @room = helper.createRoom(httpd: false)
 
@@ -86,7 +87,7 @@ describe 'watch-web-resources', ->
 
   context 'pchaigno asks if any web resource changed', ->
     beforeEach ->
-      @room.robot.brain.set 'web_resources', {'https://github.com': '', 'https://twitter.com': ''}
+      @room.robot.brain.set 'web_resources', {'github.com': '', 'twitter.com': ''}
       co =>
         yield @room.user.say 'pchaigno', 'hubot: did any web resource change?'
         yield new Promise.delay(1000)
@@ -94,8 +95,8 @@ describe 'watch-web-resources', ->
     it 'answers with the url of the changed resources', ->
       expect(@room.messages).to.eql [
         ['pchaigno', 'hubot: did any web resource change?']
-        ['hubot', "https://github.com changed"]
-        ['hubot', "https://twitter.com changed"]
+        ['hubot', "github.com changed"]
+        ['hubot', "twitter.com changed"]
       ]
       expect(@room.robot.brain.get('web_resources')['github.com']).to.not.eql ''
 

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -61,15 +61,16 @@ describe 'watch-web-resources', ->
 
   context 'pchaigno asks if any web resource changed', ->
     beforeEach ->
-      @room.robot.brain.set 'web_resources', {'https://github.com': ''}
+      @room.robot.brain.set 'web_resources', {'https://github.com': '', 'https://twitter.com': ''}
       co =>
         yield @room.user.say 'pchaigno', 'hubot: did any web resource change?'
         yield new Promise.delay(1000)
 
-    it 'answers that github.com did change', ->
+    it 'answers with the url of the resources which changed', ->
       expect(@room.messages).to.eql [
         ['pchaigno', 'hubot: did any web resource change?']
         ['hubot', "https://github.com changed"]
+        ['hubot', "https://twitter.com changed"]
       ]
       expect(@room.robot.brain.get('web_resources')['https://github.com']).to.not.eql ''
 

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -20,7 +20,21 @@ describe 'watch-web-resources', ->
         ['pchaigno', 'hubot: watch https://github.com']
         ['hubot', "@pchaigno Resource looks good. I'll keep you informed."]
       ]
-      expect(Object.keys(@room.robot.brain.get('web_resources'))).to.eql ['https://github.com']
+      expect(Object.keys(@room.robot.brain.get('web_resources'))).to.eql ['github.com']
+      expect(@room.robot.brain.get('room_web_resources')).to.eql 'room1'
+
+  context "pchaigno wants to monitor a new web resource, but doesn't specify the protocol", ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'pchaigno', 'hubot: watch travis-ci.org'
+        yield new Promise.delay(1000)
+
+    it 'saves the resource in memory after checking it', ->
+      expect(@room.messages).to.eql [
+        ['pchaigno', 'hubot: watch travis-ci.org']
+        ['hubot', "@pchaigno Resource looks good. I'll keep you informed."]
+      ]
+      expect(Object.keys(@room.robot.brain.get('web_resources'))).to.eql ['travis-ci.org']
       expect(@room.robot.brain.get('room_web_resources')).to.eql 'room1'
 
   context 'pchaigno wants to monitor an inexistant web resource', ->
@@ -39,13 +53,13 @@ describe 'watch-web-resources', ->
 
   context 'someone asks for the list of monitored web resources', ->
     beforeEach ->
-      @room.robot.brain.set 'web_resources', {'https://github.com': ''}
+      @room.robot.brain.set 'web_resources', {'github.com': ''}
       @room.user.say 'bob', 'hubot: what are you watching?'
 
     it "answers with the list of monitored web resources", ->
       expect(@room.messages).to.eql [
         ['bob', 'hubot: what are you watching?']
-        ['hubot', "@bob https://github.com"]
+        ['hubot', "@bob github.com"]
       ]
 
   context 'someone asks for the list of monitored web resources', ->
@@ -60,7 +74,7 @@ describe 'watch-web-resources', ->
 
   context 'pchaigno does not care for github.com anymore', ->
     beforeEach ->
-      @room.robot.brain.set 'web_resources', {'https://github.com': ''}
+      @room.robot.brain.set 'web_resources', {'github.com': ''}
       @room.user.say 'pchaigno', 'hubot: stop watching https://github.com'
 
     it 'removes github.com from the web resources to monitor', ->
@@ -83,7 +97,7 @@ describe 'watch-web-resources', ->
         ['hubot', "https://github.com changed"]
         ['hubot', "https://twitter.com changed"]
       ]
-      expect(@room.robot.brain.get('web_resources')['https://github.com']).to.not.eql ''
+      expect(@room.robot.brain.get('web_resources')['github.com']).to.not.eql ''
 
   context 'pchaigno asks if any web resource changed', ->
     beforeEach ->

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -20,7 +20,7 @@ describe 'watch-web-resources', ->
         ['pchaigno', 'hubot: watch https://github.com']
         ['hubot', "@pchaigno Resource looks good. I'll keep you informed."]
       ]
-      expect(@room.robot.brain.get('web_resources')).to.eql ['https://github.com']
+      expect(Object.keys(@room.robot.brain.get('web_resources'))).to.eql ['https://github.com']
 
   context 'pchaigno wants to monitor an inexistant web resource', ->
     beforeEach ->
@@ -38,7 +38,7 @@ describe 'watch-web-resources', ->
 
   context 'someone asks for the list of monitored web resources', ->
     beforeEach ->
-      @room.robot.brain.set 'web_resources', ['https://github.com']
+      @room.robot.brain.set 'web_resources', {'https://github.com': ''}
       @room.user.say 'bob', 'hubot: what are you watching?'
 
     it "answers with the list of monitored web resources", ->
@@ -49,7 +49,7 @@ describe 'watch-web-resources', ->
 
   context 'pchaigno does not care for github.com anymore', ->
     beforeEach ->
-      @room.robot.brain.set 'web_resources', ['https://github.com']
+      @room.robot.brain.set 'web_resources', {'https://github.com': ''}
       @room.user.say 'pchaigno', 'hubot: stop watching https://github.com'
 
     it 'removes github.com from the web resources to monitor', ->
@@ -57,4 +57,4 @@ describe 'watch-web-resources', ->
         ['pchaigno', 'hubot: stop watching https://github.com']
         ['hubot', "@pchaigno Less work? Aww..."]
       ]
-      expect(@room.robot.brain.get('web_resources')).to.eql []
+      expect(@room.robot.brain.get('web_resources')).to.eql {}


### PR DESCRIPTION
Should replace one of Patrique's two functionalities.

Missing:
- [x] Manage the list of resources to monitor.
- [x] Actually monitor the resources.
- [x] Prevent huge resources from being added.
- [x] Remove huge resources from the list.
- [ ] Extract text from HTTP web resources.
- [ ] Manage concurrent accesses to the list.
- [ ] Allow huge resources and monitor the `last_edit_time` instead of the content.
- [x] Save the room where notifications should be sent.
- [x] Initialize the periodic check when the bot starts.
- [x] Allow URLs without the protocol (e.g., `github.com`).