### PR TITLE
Hubot Github Trending script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "mocha": "^2.2.5",
     "bluebird": "^3.3.1",
     "co": "^4.6.0",
-    "cheerio": "^0.20.0"
+    "cheerio": "^0.20.0",
+    "request": "^2.69.0"
   },
   "engines": {
     "node": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "coffee-script": "^1.9.3",
     "mocha": "^2.2.5",
     "bluebird": "^3.3.1",
-    "co": "^4.6.0"
+    "co": "^4.6.0",
+    "cheerio": "^0.20.0"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/github-trending.js
+++ b/scripts/github-trending.js
@@ -1,0 +1,68 @@
+// Description:
+//   get the latest trending repositories on github
+//
+// Dependencies:
+//   cheerio
+//   request
+//
+// Configuration:
+//   None
+//
+// Commands:
+//   trending          : list trending repositories (all languages)
+//   trending-language : list trending repositories for the given language
+//   trending project  : get general information for the given project
+//
+
+var cheerio = require('cheerio');
+var request = require('request')
+
+module.exports = function(robot) {
+
+  robot.respond(/trending$/i, function(msg){
+    request('https://github.com/trending', function(error, response, body){
+      if (!error && response.statusCode == 200) {
+        $ = cheerio.load(body);
+
+        var results = [];
+
+        $('h3').each(function(i, elem) {
+          var link = $(this).children('a').attr("href");
+          results.push(link);
+        });
+
+        msg.send(results.join(' - '));
+      }
+    });
+  });
+
+  robot.respond(/trending-(.*)$/i, function(msg){
+    var language = msg.match[1];
+    request('https://github.com/trending/'+language, function(error, response, body){
+      if (!error && response.statusCode == 200) {
+        $ = cheerio.load(body);
+
+        var results = [];
+
+        $('h3').each(function(i, elem) {
+          var link = $(this).children('a').attr("href");
+          results.push(link);
+        });
+
+        msg.send(results.join(' - '));
+      }
+    });
+  });
+
+  robot.respond(/trending (.*)$/i, function(msg){
+    var project = msg.match[1];
+    request('https://github.com/'+project, function(error, response, body){
+      if (!error && response.statusCode == 200) {
+        $ = cheerio.load(body);
+
+        msg.send( $('.repository-meta-content').text().trim() );
+      }
+    });
+  });
+
+}

--- a/tests/github-trending.coffee
+++ b/tests/github-trending.coffee
@@ -1,5 +1,5 @@
 Helper = require('hubot-test-helper')
-helper = new Helper('./../node_modules/hubot-url-title/src/scripts/github-trending.js')
+helper = new Helper('./../scripts/github-trending.js')
 
 Promise = require('bluebird')
 co = require('co')

--- a/tests/github-trending.coffee
+++ b/tests/github-trending.coffee
@@ -1,0 +1,58 @@
+Helper = require('hubot-test-helper')
+helper = new Helper('./../node_modules/hubot-url-title/src/scripts/github-trending.js')
+
+Promise = require('bluebird')
+co = require('co')
+expect = require('chai').expect
+
+describe 'github-trending', ->
+  beforeEach ->
+    @room = helper.createRoom(httpd: false)
+
+  context "user asks for the trending repositories", ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'john', "trending"
+        yield new Promise.delay(500)
+
+    it 'get the trending projects', ->
+      expect(@room.messages).to.eql [
+        ['john', "trending"]
+        ['hubot', "/facebook/draft-js - /santinic/how2 - /FreeCodeCamp/FreeCodeCamp - /IBM-Swift/Kitura - /VPenkov/okayNav - /necolt/Swifton - /qutheory/vapor - /ImagicalMine/ImagicalMine - /allenwong/30DaysofSwift - /callmecavs/bricks.js - /vulpino/jolteon - /Freelander/Android_Data - /realm/realm-js - /jaredpalmer/react-production-starter - /gleitz/howdoi - /sqren/fb-sleep-stats - /Thomas101/wmail - /kean/Nuke - /byoutline/kickmaterial - /lmatteis/peer-tweet - /unicodeveloper/laravel-hackathon-starter - /ArnaudValensi/docker-parse-server-git-deploy - /substance/substance - /brrd/Abricotine - /TomWithJerry/CoolAndroidAnim"]
+      ]
+
+  context "user asks for the trending repositories in python language", ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'john', "trending-python"
+        yield new Promise.delay(500)
+
+    it 'get the python trending projects', ->
+      expect(@room.messages).to.eql [
+        ['john', "trending-python"]
+        ['hubot', "/gleitz/howdoi - /timothycrosley/hug - /defaultnamehere/zzzzz - /soimort/you-get - /letsencrypt/letsencrypt - /jflesch/paperwork - /vlall/darksearch - /Urinx/WeixinBot - /dizballanze/do-latency - /rg3/youtube-dl - /pluralsight/guides-cms - /dhruvramani/Terminal-on-FB-Messenger - /p-e-w/maybe - /XX-net/XX-Net - /vinta/awesome-python - /chrissimpkins/codeface - /kennethreitz/requests - /scrapy/scrapy - /lamerman/shellpy - /scikit-learn/scikit-learn - /Valloric/YouCompleteMe - /EliotBerriot/lifter - /praetorian-inc/pentestly - /mitsuhiko/flask - /jkbrzt/httpie"]
+      ]
+
+  context "user asks for informations on a project", ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'john', "trending /santinic/how2"
+        yield new Promise.delay(500)
+
+    it 'get the python trending projects', ->
+      expect(@room.messages).to.eql [
+        ['john', "trending /santinic/how2"]
+        ['hubot', "stackoverflow from the terminal"]
+      ]
+
+  context "user asks for informations on a project that does not exists", ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'john', "trending /bad_user/bad_project"
+        yield new Promise.delay(500)
+
+    it 'get the python trending projects', ->
+      expect(@room.messages).to.eql [
+        ['john', "trending /bad_user/bad_project"]
+        ['hubot', ""]
+      ]

--- a/tests/github-trending.coffee
+++ b/tests/github-trending.coffee
@@ -12,47 +12,46 @@ describe 'github-trending', ->
   context "user asks for the trending repositories", ->
     beforeEach ->
       co =>
-        yield @room.user.say 'john', "trending"
+        yield @room.user.say 'john', "hubot trending"
         yield new Promise.delay(500)
 
     it 'get the trending projects', ->
       expect(@room.messages).to.eql [
-        ['john', "trending"]
+        ['john', "hubot trending"]
         ['hubot', "/facebook/draft-js - /santinic/how2 - /FreeCodeCamp/FreeCodeCamp - /IBM-Swift/Kitura - /VPenkov/okayNav - /necolt/Swifton - /qutheory/vapor - /ImagicalMine/ImagicalMine - /allenwong/30DaysofSwift - /callmecavs/bricks.js - /vulpino/jolteon - /Freelander/Android_Data - /realm/realm-js - /jaredpalmer/react-production-starter - /gleitz/howdoi - /sqren/fb-sleep-stats - /Thomas101/wmail - /kean/Nuke - /byoutline/kickmaterial - /lmatteis/peer-tweet - /unicodeveloper/laravel-hackathon-starter - /ArnaudValensi/docker-parse-server-git-deploy - /substance/substance - /brrd/Abricotine - /TomWithJerry/CoolAndroidAnim"]
       ]
 
   context "user asks for the trending repositories in python language", ->
     beforeEach ->
       co =>
-        yield @room.user.say 'john', "trending-python"
+        yield @room.user.say 'john', "hubot trending-python"
         yield new Promise.delay(500)
 
     it 'get the python trending projects', ->
       expect(@room.messages).to.eql [
-        ['john', "trending-python"]
+        ['john', "hubot trending-python"]
         ['hubot', "/gleitz/howdoi - /timothycrosley/hug - /defaultnamehere/zzzzz - /soimort/you-get - /letsencrypt/letsencrypt - /jflesch/paperwork - /vlall/darksearch - /Urinx/WeixinBot - /dizballanze/do-latency - /rg3/youtube-dl - /pluralsight/guides-cms - /dhruvramani/Terminal-on-FB-Messenger - /p-e-w/maybe - /XX-net/XX-Net - /vinta/awesome-python - /chrissimpkins/codeface - /kennethreitz/requests - /scrapy/scrapy - /lamerman/shellpy - /scikit-learn/scikit-learn - /Valloric/YouCompleteMe - /EliotBerriot/lifter - /praetorian-inc/pentestly - /mitsuhiko/flask - /jkbrzt/httpie"]
       ]
 
   context "user asks for informations on a project", ->
     beforeEach ->
       co =>
-        yield @room.user.say 'john', "trending /santinic/how2"
+        yield @room.user.say 'john', "hubot trending /santinic/how2"
         yield new Promise.delay(500)
 
     it 'get the python trending projects', ->
       expect(@room.messages).to.eql [
-        ['john', "trending /santinic/how2"]
+        ['john', "hubot trending /santinic/how2"]
         ['hubot', "stackoverflow from the terminal"]
       ]
 
   context "user asks for informations on a project that does not exists", ->
     beforeEach ->
       co =>
-        yield @room.user.say 'john', "trending /bad_user/bad_project"
+        yield @room.user.say 'john', "hubot trending /bad_user/bad_project"
         yield new Promise.delay(500)
 
     it 'get the python trending projects', ->
       expect(@room.messages).to.eql [
-        ['john', "trending /bad_user/bad_project"]
-        ['hubot', ""]
+        ['john', "hubot trending /bad_user/bad_project"]
       ]

--- a/tests/github-trending.coffee
+++ b/tests/github-trending.coffee
@@ -15,10 +15,10 @@ describe 'github-trending', ->
         yield @room.user.say 'john', "hubot trending"
         yield new Promise.delay(500)
 
-    it 'get the trending projects', ->
+    it 'gets the trending projects', ->
       expect(@room.messages).to.eql [
         ['john', "hubot trending"]
-        ['hubot', "/facebook/draft-js - /santinic/how2 - /FreeCodeCamp/FreeCodeCamp - /IBM-Swift/Kitura - /VPenkov/okayNav - /necolt/Swifton - /qutheory/vapor - /ImagicalMine/ImagicalMine - /allenwong/30DaysofSwift - /callmecavs/bricks.js - /vulpino/jolteon - /Freelander/Android_Data - /realm/realm-js - /jaredpalmer/react-production-starter - /gleitz/howdoi - /sqren/fb-sleep-stats - /Thomas101/wmail - /kean/Nuke - /byoutline/kickmaterial - /lmatteis/peer-tweet - /unicodeveloper/laravel-hackathon-starter - /ArnaudValensi/docker-parse-server-git-deploy - /substance/substance - /brrd/Abricotine - /TomWithJerry/CoolAndroidAnim"]
+        ['hubot', "/dthree/cash - /FreeCodeCamp/FreeCodeCamp - /facebook/draft-js - /santinic/how2 - /copy/v86 - /ryanflorence/react-project - /ImagicalMine/ImagicalMine - /VPenkov/okayNav - /IBM-Swift/Kitura - /allenwong/30DaysofSwift - /dustturtle/RealReachability - /dthree/vorpal - /ampproject/amphtml - /legomushroom/mojs - /callmecavs/bricks.js - /xiepeijie/SwipeCardView - /gabrielrcouto/php-terminal-gameboy-emulator - /codrops/Animocons - /substance/substance - /Freelander/Android_Data - /Ramotion/circle-menu - /Zepo/MLeaksFinder - /veniversum/git-visualizer - /AllThingsSmitty/css-protips - /RFStorm/mousejack"]
       ]
 
   context "user asks for the trending repositories in python language", ->
@@ -27,10 +27,10 @@ describe 'github-trending', ->
         yield @room.user.say 'john', "hubot trending-python"
         yield new Promise.delay(500)
 
-    it 'get the python trending projects', ->
+    it 'gets the python trending projects', ->
       expect(@room.messages).to.eql [
         ['john', "hubot trending-python"]
-        ['hubot', "/gleitz/howdoi - /timothycrosley/hug - /defaultnamehere/zzzzz - /soimort/you-get - /letsencrypt/letsencrypt - /jflesch/paperwork - /vlall/darksearch - /Urinx/WeixinBot - /dizballanze/do-latency - /rg3/youtube-dl - /pluralsight/guides-cms - /dhruvramani/Terminal-on-FB-Messenger - /p-e-w/maybe - /XX-net/XX-Net - /vinta/awesome-python - /chrissimpkins/codeface - /kennethreitz/requests - /scrapy/scrapy - /lamerman/shellpy - /scikit-learn/scikit-learn - /Valloric/YouCompleteMe - /EliotBerriot/lifter - /praetorian-inc/pentestly - /mitsuhiko/flask - /jkbrzt/httpie"]
+        ['hubot', "/deepgram/sidomo - /snipsco/ntm-lasagne - /Zephrys/monica - /zero-db/zerodb - /timothycrosley/hug - /gleitz/howdoi - /ansible/ansible - /NathanEpstein/Dora - /mitsuhiko/flask - /letsencrypt/letsencrypt - /fchollet/keras - /rg3/youtube-dl - /soimort/you-get - /django/django - /openstack/bandit - /vinta/awesome-python - /XX-net/XX-Net - /tariqdaouda/pyGeno - /jflesch/paperwork - /donnemartin/data-science-ipython-notebooks - /p-e-w/maybe - /scikit-learn/scikit-learn - /kennethreitz/requests - /scrapy/scrapy - /jkbrzt/httpie"]
       ]
 
   context "user asks for informations on a project", ->
@@ -39,7 +39,7 @@ describe 'github-trending', ->
         yield @room.user.say 'john', "hubot trending /santinic/how2"
         yield new Promise.delay(500)
 
-    it 'get the python trending projects', ->
+    it 'gets the python trending projects', ->
       expect(@room.messages).to.eql [
         ['john', "hubot trending /santinic/how2"]
         ['hubot', "stackoverflow from the terminal"]
@@ -51,7 +51,7 @@ describe 'github-trending', ->
         yield @room.user.say 'john', "hubot trending /bad_user/bad_project"
         yield new Promise.delay(500)
 
-    it 'get the python trending projects', ->
+    it 'gets the python trending projects', ->
       expect(@room.messages).to.eql [
         ['john', "hubot trending /bad_user/bad_project"]
       ]


### PR DESCRIPTION
Hubot script to get the trending repositories on GitHub.

```
usage:
bot_name trending : list trending repositories (all languages)
bot_name trending-language : list trending repositories for the given language
bot_name trending project : get general information for the given project (or nothing)
```