### PR TITLE
Temporary fix for hubot-google-translate

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "hubot": ">= 2.6.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.2.4",
-    "hubot-google-translate": "^0.2.0",
+    "hubot-google-translate": "awailly/hubot-google-translate#fix-tests",
     "hubot-help": "^0.1.2",
     "hubot-heroku-keepalive": "^1.0.0",
     "hubot-irc": "^0.2.8",


### PR DESCRIPTION
Use @awailly's fork of [hubot-google-translate](hubot-scripts/hubot-google-translate) while we wait for hubot-scripts/hubot-google-translate#11 to be merged.