### PR TITLE
Update hubot-url-title

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.16.2",
     "hubot-shipit": "^0.2.0",
-    "hubot-url-title": "^1.2.2",
+    "hubot-url-title": "^1.3",
     "hubot-wikipedia": "0.0.2",
     "optparse": "1.0.3",
     "request": "^2.69.0"


### PR DESCRIPTION
Fixes a few bugs:
- enforces a maximum download size;
- recognizes messages with several urls.