### PR TITLE
Watch only the text of HTML resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "crypto": "0.0.3",
+    "fs": "0.0.2",
+    "html-to-text": "^2.1.0",
     "hubot": ">= 2.6.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.2.4",

--- a/scripts/hash-web-resources.coffee
+++ b/scripts/hash-web-resources.coffee
@@ -1,6 +1,13 @@
 crypto = require 'crypto'
+htmlToText = require 'html-to-text'
+fs = require 'fs'
+
+extractText = (body) ->
+  return htmlToText.fromString body
 
 module.exports = {
   computeHash: (body, contentType) ->
+    if contentType and /text\/html/.test(contentType)
+      body = extractText(body)
     return crypto.createHash("sha256").update(body).digest("base64")
 }

--- a/scripts/hash-web-resources.coffee
+++ b/scripts/hash-web-resources.coffee
@@ -1,0 +1,6 @@
+crypto = require 'crypto'
+
+module.exports = {
+  computeHash: (body, contentType) ->
+    return crypto.createHash("sha256").update(body).digest("base64")
+}

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -35,7 +35,7 @@ changedWebResource = (robot, room, resource, hash) ->
       if err
         newHash = 0
       else if response.statusCode is 200
-        newHash = hasher.computeHash body
+        newHash = hasher.computeHash body, response.headers['content-type']
         if newHash is hash
           newHash = null
       else

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -15,16 +15,13 @@
 # Author:
 #   Paul Chaignon <paul.chaignon@gmail.com>
 
-crypto = require "crypto"
 request = require "request"
+hasher = require './hash-web-resources.coffee'
 
 PERIODIC_CHECKS_INTERVAL = 10000
 MAX_SIZE_DOWNLOADED_FILES = 1000000
 periodicCheckId = null
 firstPeriodicCheck = true
-
-computeHash = (body) ->
-  return crypto.createHash("sha256").update(body).digest("base64")
 
 changedWebResources = (robot, room) ->
   resources = robot.brain.get('web_resources') or {}
@@ -38,7 +35,7 @@ changedWebResource = (robot, room, resource, hash) ->
       if err
         newHash = 0
       else if response.statusCode is 200
-        newHash = computeHash body
+        newHash = hasher.computeHash body
         if newHash is hash
           newHash = null
       else
@@ -95,7 +92,7 @@ module.exports = (robot) ->
         res.reply "Are you sure about that url?"
         res.send "#{err}"
       else if response.statusCode is 200
-        hash = computeHash(body)
+        hash = hasher.computeHash(body)
         resources = robot.brain.get('web_resources') or {}
         resources[res.match[2]] = hash
         robot.brain.set 'web_resources', resources

--- a/tests/test_reponses/github1.html
+++ b/tests/test_reponses/github1.html
@@ -1,0 +1,391 @@
+
+
+
+<!DOCTYPE html>
+<html lang="en" class=" is-copy-enabled">
+  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
+    <meta charset='utf-8'>
+
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-3c1694fab1568340f2e75b26efa1f55d97c5153364a7357e9e1104c718ff1a2f.css" integrity="sha256-PBaU+rFWg0Dy51sm76H1XZfFFTNkpzV+nhEExxj/Gi8=" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-3e95d73eb454e0099947df00d91ab0dbfc6b10be69dd5daf5de7aeb676580d20.css" integrity="sha256-PpXXPrRU4AmZR98A2Rqw2/xrEL5p3V2vXeeutnZYDSA=" media="all" rel="stylesheet" />
+    
+    
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-c4b4365da282e51c06e107368db8502a2ecf82e64094d29d791b797372212de2.css" integrity="sha256-xLQ2XaKC5RwG4Qc2jbhQKi7PguZAlNKdeRt5c3IhLeI=" media="all" rel="stylesheet" />
+    
+
+    <link as="script" href="https://assets-cdn.github.com/assets/frameworks-851de55546d87ad786f3efef3b5634f8f8a40d67fa6d44f854d9e99767e9c9a2.js" rel="preload" />
+    
+    <link as="script" href="https://assets-cdn.github.com/assets/github-9a6de3c5d3dd93cd9d6638a6d1bcc27eb7cbf9afdd082771ea900f9996597a24.js" rel="preload" />
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+    <meta content="origin-when-cross-origin" name="referrer" />
+    
+    <title>How people build software · GitHub</title>
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
+    <meta property="fb:app_id" content="1401488693436528">
+
+      <meta property="og:url" content="https://github.com">
+      <meta property="og:site_name" content="GitHub">
+      <meta property="og:title" content="Build software better, together">
+      <meta property="og:description" content="GitHub is where people build software. More than 14 million people use GitHub to discover, fork, and contribute to over 35 million projects.">
+      <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-logo.png">
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="1200">
+      <meta property="og:image:height" content="1200">
+      <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-mark.png">
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="1200">
+      <meta property="og:image:height" content="620">
+      <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png">
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="1200">
+      <meta property="og:image:height" content="620">
+      <meta property="twitter:site" content="github">
+      <meta property="twitter:site:id" content="13334762">
+      <meta property="twitter:creator" content="github">
+      <meta property="twitter:creator:id" content="13334762">
+      <meta property="twitter:card" content="summary_large_image">
+      <meta property="twitter:title" content="GitHub">
+      <meta property="twitter:description" content="GitHub is where people build software. More than 14 million people use GitHub to discover, fork, and contribute to over 35 million projects.">
+      <meta property="twitter:image:src" content="https://assets-cdn.github.com/images/modules/open_graph/github-logo.png">
+      <meta property="twitter:image:width" content="1200">
+      <meta property="twitter:image:height" content="1200">
+      <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+    <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+    <link rel="assets" href="https://assets-cdn.github.com/">
+    
+    <meta name="pjax-timeout" content="1000">
+    
+
+    <meta name="msapplication-TileImage" content="/windows-tile.png">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="selected-link" value="/" data-pjax-transient>
+
+    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+<meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-analytics" content="UA-3769691-2">
+
+<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="56F6086D:6DA2:1E50828:5736FEDA" name="octolytics-dimension-request_id" />
+
+
+
+
+  <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
+
+
+        <meta name="hostname" content="github.com">
+    <meta name="user-login" content="">
+
+        <meta name="expected-hostname" content="github.com">
+      <meta name="js-proxy-site-detection-payload" content="Yjk0NjAxMzhmOTgzNzgwZjdlOTY1NjkzOGEzYjE4YWM2YTZiN2I3NmFmODgxYzY2YjMxZWM0ZDMwYzFlOGI5OHx7InJlbW90ZV9hZGRyZXNzIjoiODYuMjQ2LjguMTA5IiwicmVxdWVzdF9pZCI6IjU2RjYwODZEOjZEQTI6MUU1MDgyODo1NzM2RkVEQSIsInRpbWVzdGFtcCI6MTQ2MzIyMTk3OH0=">
+
+
+      <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#4078c0">
+      <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
+
+    <meta content="8d9e23ba9977ffec7be03eedd55f71796fdcfa3a" name="form-nonce" />
+
+    <meta http-equiv="x-pjax-version" content="a4cb11b734331d95088899b1377fb05e">
+    
+
+        <meta name="viewport" content="width=device-width">
+  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-c4b4365da282e51c06e107368db8502a2ecf82e64094d29d791b797372212de2.css" integrity="sha256-xLQ2XaKC5RwG4Qc2jbhQKi7PguZAlNKdeRt5c3IhLeI=" media="all" rel="stylesheet" />
+
+
+      <link rel="canonical" href="https://github.com/" data-pjax-transient>
+  </head>
+
+
+  <body class="logged-out   env-production linux  page-responsive">
+    <div id="js-pjax-loader-bar" class="pjax-loader-bar"></div>
+    <a href="#start-of-content" tabindex="1" class="accessibility-aid js-skip-to-content">Skip to content</a>
+
+    
+    
+    
+
+
+
+          <header class="site-header js-details-container" role="banner">
+  <div class="container-responsive">
+    <a class="header-logo-invertocat" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
+    </a>
+
+    <button class="btn-link right site-header-toggle js-details-target" type="button" aria-label="Toggle navigation">
+      <svg aria-hidden="true" class="octicon octicon-three-bars" height="24" version="1.1" viewBox="0 0 12 16" width="18"><path d="M11.41 9H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1z m0-4H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1zM0.59 11h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1z"></path></svg>
+    </button>
+
+    <div class="site-header-menu">
+      <nav class="site-header-nav site-header-nav-main">
+        <a href="/personal" class="js-selected-navigation-item nav-item nav-item-personal" data-ga-click="Header, click, Nav menu - item:personal" data-selected-links="/personal /personal">
+          Personal
+</a>        <a href="/open-source" class="js-selected-navigation-item nav-item nav-item-opensource" data-ga-click="Header, click, Nav menu - item:opensource" data-selected-links="/open-source /open-source">
+          Open source
+</a>        <a href="/business" class="js-selected-navigation-item nav-item nav-item-business" data-ga-click="Header, click, Nav menu - item:business" data-selected-links="/business /business/features /business/customers /business">
+          Business
+</a>        <a href="/explore" class="js-selected-navigation-item nav-item nav-item-explore" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship /explore">
+          Explore
+</a>      </nav>
+
+      <div class="site-header-actions">
+            <a class="btn btn-primary site-header-actions-btn" href="/join?source=header-home" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
+          <a class="btn site-header-actions-btn mr-2" href="/login" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
+      </div>
+
+        <nav class="site-header-nav site-header-nav-secondary">
+          <a class="nav-item" href="/pricing">Pricing</a>
+          <a class="nav-item" href="/blog">Blog</a>
+          <a class="nav-item" href="https://help.github.com">Support</a>
+          <a class="nav-item header-search-link" href="https://github.com/search">Search GitHub</a>
+              <div class="header-search   js-site-search" role="search">
+  <!-- </textarea> --><!-- '"` --><form accept-charset="UTF-8" action="/search" class="js-site-search-form" data-unscoped-search-url="/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+    <label class="form-control header-search-wrapper js-chromeless-input-container">
+      <div class="header-search-scope"></div>
+      <input type="text"
+        class="form-control header-search-input js-site-search-focus "
+        data-hotkey="s"
+        name="q"
+        placeholder="Search GitHub"
+        aria-label="Search GitHub"
+        data-unscoped-placeholder="Search GitHub"
+        data-scoped-placeholder="Search"
+        tabindex="1"
+        autocapitalize="off">
+    </label>
+</form></div>
+
+        </nav>
+    </div>
+  </div>
+</header>
+
+
+
+
+    <div id="start-of-content" class="accessibility-aid"></div>
+
+      <div id="js-flash-container">
+</div>
+
+
+    <div role="main" class="main-content">
+        
+<div class="jumbotron jumbotron-home jumbotron-inverse">
+  <div class="container-responsive">
+    <div class="columns">
+      <div class="homepage-hero-intro column">
+        <h1 class="display-heading-1 jumbotron-title">How&nbsp;people build&nbsp;software</h1>
+        <p class="display-intro jumbotron-lead">Millions of developers use GitHub to build personal projects, support their businesses, and&nbsp;work together on open source technologies.</p>
+      </div>
+      <div class="homepage-hero-signup column">
+          <div class="d-none-sm-dn">
+            <!-- </textarea> --><!-- '"` --><form accept-charset="UTF-8" action="/join" autocomplete="off" class="home-hero-signup js-signup-form" data-form-nonce="8d9e23ba9977ffec7be03eedd55f71796fdcfa3a" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="/3xDqHBqrLt3DekMfhxMO8UQA5y/PybHKsF0rqh5R8UzYBP0fTlGJVAKl99zT9So3E6RYFM85iLEzKW3Pxi5YQ==" /></div>              <dl class="form">
+                <dd>
+                  <label class="form-label sr-only" for="user[login]">Pick a username</label>
+                  <input type="text" name="user[login]" class="form-control form-control-lg input-block" placeholder="Pick a username" data-autocheck-url="/signup_check/username" autofocus>
+                </dd>
+              </dl>
+              <dl class="form">
+                <dd>
+                  <label class="form-label sr-only" for="user[email]">Enter your email address</label>
+                  <input type="text" name="user[email]" class="form-control form-control-lg input-block js-email-notice-trigger" placeholder="Your email address" data-autocheck-url="/signup_check/email">
+                </dd>
+              </dl>
+              <dl class="form">
+                <dd>
+                  <label class="form-label sr-only" for="user[password]">Create a password</label>
+                  <input type="password" name="user[password]" class="form-control form-control-lg input-block" placeholder="Create a password" data-autocheck-url="/signup_check/password">
+                </dd>
+                <p class="form-control-note">Use at least one letter, one numeral, and seven characters.</p>
+              </dl>
+              <input type="hidden" name="source" class="js-signup-source" value="form-home">
+              <button class="btn btn-theme-green btn-jumbotron btn-block" type="submit">Sign up for GitHub</button>
+              <p class="form-control-note text-center">
+                By clicking "Sign up for GitHub", you agree to our
+                <a class="text-white" href="https://help.github.com/terms" target="_blank">terms of service</a> and
+                <a class="text-white" href="https://help.github.com/privacy" target="_blank">privacy policy</a>. <span class="js-email-notice">We'll occasionally send you account related emails.</span>
+              </p>
+</form>          </div>
+          <div class="d-none-md-up">
+            <a href="/join?source=button-home" class="btn btn-theme-green btn-jumbotron" rel="nofollow">Sign up for GitHub</a>
+          </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette bg-white py-5">
+  <div class="container-responsive">
+    <div class="columns">
+      <div class="one-third column">
+        <h3 class="display-heading-3" style="line-height: 1.2;">Introducing unlimited <br class="d-none-sm-dn">private&nbsp;repositories</h3>
+      </div>
+      <div class="two-thirds column">
+        <p class="mt-2 mb-0">All of our paid plans on GitHub.com now include unlimited private repositories. <a href="/join">Sign&nbsp;up</a>&nbsp;to get started or <a href="https://github.com/blog/2164-introducing-unlimited-private-repositories">read more about this change on our blog</a>.</p>
+        
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette pb-0 pt-6 shade-gray border-top">
+  <div class="container-responsive">
+    <h2 class="featurette-heading display-heading-2 mt-3 text-center">Welcome home, developers</h2>
+    <p class="featurette-lead featurette-lead-center display-intro mb-6 pb-4">GitHub fosters a fast, flexible, and collaborative development process that lets you work on your own or with others.</p>
+  </div>
+  <div class="tile-block">
+    <div class="tile-row">
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-build.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">For everything you build</h4>
+        <p class="display-body-sm">Host and manage your code on GitHub. You can keep your work private or share it with the world.</p>
+      </div>
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-work.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">A better way to work</h4>
+        <p class="display-body-sm">From hobbyists to professionals, GitHub helps developers simplify the way they build software.</p>
+      </div>
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-projects.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">Millions of projects</h4>
+        <p class="display-body-sm">GitHub is home to millions of open source projects. Try one out or get inspired to create your own.</p>
+      </div>
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-platform.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">One platform, from start to finish</h4>
+        <p class="display-body-sm">With hundreds of integrations, GitHub is flexible enough to be at the center of your development process.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette pb-0">
+  <div class="container-responsive">
+    <h2 class="display-heading-2">Who uses GitHub?</h2>
+    <hr class="triband-hr mt-5 mb-0">
+    <div class="columns">
+      <div class="one-third column my-4">
+        <h3 class="display-heading-3 mt-2"><a href="/personal" class="text-blue octicon-middle">Individuals <svg aria-hidden="true" class="octicon octicon-chevron-right" height="16" version="1.1" viewBox="0 0 8 16" width="8"><path d="M7.5 8L2.5 13l-1.5-1.5 3.75-3.5L1 4.5l1.5-1.5 5 5z"></path></svg></a></h3>
+        <p>Use GitHub to create a personal project, whether you want to experiment with a new programming language or host your life’s work.</p>
+      </div>
+      <div class="one-third column my-4">
+        <h3 class="display-heading-3 mt-2"><a href="/open-source" class="text-orange octicon-middle">Communities <svg aria-hidden="true" class="octicon octicon-chevron-right" height="16" version="1.1" viewBox="0 0 8 16" width="8"><path d="M7.5 8L2.5 13l-1.5-1.5 3.75-3.5L1 4.5l1.5-1.5 5 5z"></path></svg></a></h3>
+        <p>GitHub hosts one of the largest collections of open source software. Create, manage, and work on some of today’s most influential technologies.</p>
+      </div>
+      <div class="one-third column my-4">
+        <h3 class="display-heading-3 mt-2"><a href="/business" class="text-purple octicon-middle">Businesses <svg aria-hidden="true" class="octicon octicon-chevron-right" height="16" version="1.1" viewBox="0 0 8 16" width="8"><path d="M7.5 8L2.5 13l-1.5-1.5 3.75-3.5L1 4.5l1.5-1.5 5 5z"></path></svg></a></h3>
+        <p>Businesses of all sizes use GitHub to support their development process and securely build software.</p>
+      </div>
+    </div>
+    <hr class="triband-hr mt-0">
+    <div class="columns columns-vertically-centered columns-reverse mt-6">
+      <div class="one-third column">
+        <p class="display-body-sm">
+          GitHub is proud to host projects and organizations like <a href="//github.com/nasa">NASA</a>.
+        </p>
+      </div>
+      <div class="two-thirds column">
+        <img src="https://assets-cdn.github.com/images/modules/site/org_example_nasa.png?sn" class="img-responsive org-example-drop-shadow" alt="NASA is on GitHub">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette shade-gradient pb-4">
+  <div class="container-responsive">
+    <div class="pricing-card pricing-card-horizontal">
+      <div class="pricing-card-cta">
+        <a href="/join?source=button-home" class="btn btn-block btn-theme-green btn-jumbotron" rel="nofollow">Sign up for GitHub</a>
+      </div>
+      <div class="pricing-card-text display-heading-3 mb-0 text-thin">
+          Public projects are always free. Work together across unlimited private repositories for $7 / month.
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div class="modal-backdrop"></div>
+
+    </div>
+
+        <div class="container site-footer-container">
+  <div class="site-footer" role="contentinfo">
+    <ul class="site-footer-links right">
+        <li><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
+      <li><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
+      <li><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
+      <li><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
+        <li><a href="https://github.com/blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
+        <li><a href="https://github.com/about" data-ga-click="Footer, go to about, text:about">About</a></li>
+
+    </ul>
+
+    <a href="https://github.com" aria-label="Homepage" class="site-footer-mark" title="GitHub">
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" version="1.1" viewBox="0 0 16 16" width="24"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
+</a>
+    <ul class="site-footer-links">
+      <li>&copy; 2016 <span title="0.01152s from github-fe139-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+        <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
+        <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
+        <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li><a href="https://github.com/contact" data-ga-click="Footer, go to contact, text:contact">Contact</a></li>
+        <li><a href="https://help.github.com" data-ga-click="Footer, go to help, text:help">Help</a></li>
+    </ul>
+  </div>
+</div>
+
+
+
+    
+
+    <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
+      <button type="button" class="flash-close js-flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+        <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
+      </button>
+      Something went wrong with that request. Please try again.
+    </div>
+
+
+      
+      <script crossorigin="anonymous" integrity="sha256-hR3lVUbYeteG8+/vO1Y0+PikDWf6bUT4VNnpl2fpyaI=" src="https://assets-cdn.github.com/assets/frameworks-851de55546d87ad786f3efef3b5634f8f8a40d67fa6d44f854d9e99767e9c9a2.js"></script>
+      <script async="async" crossorigin="anonymous" integrity="sha256-mm3jxdPdk82dZjim0bzCfrfL+a/dCCdx6pAPmZZZeiQ=" src="https://assets-cdn.github.com/assets/github-9a6de3c5d3dd93cd9d6638a6d1bcc27eb7cbf9afdd082771ea900f9996597a24.js"></script>
+      
+      
+      
+      
+      
+      
+    <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner hidden">
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
+      <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+      <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    </div>
+    <div class="facebox" id="facebox" style="display:none;">
+  <div class="facebox-popup">
+    <div class="facebox-content" role="dialog" aria-labelledby="facebox-header" aria-describedby="facebox-description">
+    </div>
+    <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
+      <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
+    </button>
+  </div>
+</div>
+
+  </body>
+</html>
+

--- a/tests/test_reponses/github2.html
+++ b/tests/test_reponses/github2.html
@@ -1,0 +1,391 @@
+
+
+
+<!DOCTYPE html>
+<html lang="en" class=" is-copy-enabled">
+  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
+    <meta charset='utf-8'>
+
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-3c1694fab1568340f2e75b26efa1f55d97c5153364a7357e9e1104c718ff1a2f.css" integrity="sha256-PBaU+rFWg0Dy51sm76H1XZfFFTNkpzV+nhEExxj/Gi8=" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-3e95d73eb454e0099947df00d91ab0dbfc6b10be69dd5daf5de7aeb676580d20.css" integrity="sha256-PpXXPrRU4AmZR98A2Rqw2/xrEL5p3V2vXeeutnZYDSA=" media="all" rel="stylesheet" />
+    
+    
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-c4b4365da282e51c06e107368db8502a2ecf82e64094d29d791b797372212de2.css" integrity="sha256-xLQ2XaKC5RwG4Qc2jbhQKi7PguZAlNKdeRt5c3IhLeI=" media="all" rel="stylesheet" />
+    
+
+    <link as="script" href="https://assets-cdn.github.com/assets/frameworks-851de55546d87ad786f3efef3b5634f8f8a40d67fa6d44f854d9e99767e9c9a2.js" rel="preload" />
+    
+    <link as="script" href="https://assets-cdn.github.com/assets/github-9a6de3c5d3dd93cd9d6638a6d1bcc27eb7cbf9afdd082771ea900f9996597a24.js" rel="preload" />
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+    <meta content="origin-when-cross-origin" name="referrer" />
+    
+    <title>How people build software · GitHub</title>
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
+    <meta property="fb:app_id" content="1401488693436528">
+
+      <meta property="og:url" content="https://github.com">
+      <meta property="og:site_name" content="GitHub">
+      <meta property="og:title" content="Build software better, together">
+      <meta property="og:description" content="GitHub is where people build software. More than 14 million people use GitHub to discover, fork, and contribute to over 35 million projects.">
+      <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-logo.png">
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="1200">
+      <meta property="og:image:height" content="1200">
+      <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-mark.png">
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="1200">
+      <meta property="og:image:height" content="620">
+      <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png">
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="1200">
+      <meta property="og:image:height" content="620">
+      <meta property="twitter:site" content="github">
+      <meta property="twitter:site:id" content="13334762">
+      <meta property="twitter:creator" content="github">
+      <meta property="twitter:creator:id" content="13334762">
+      <meta property="twitter:card" content="summary_large_image">
+      <meta property="twitter:title" content="GitHub">
+      <meta property="twitter:description" content="GitHub is where people build software. More than 14 million people use GitHub to discover, fork, and contribute to over 35 million projects.">
+      <meta property="twitter:image:src" content="https://assets-cdn.github.com/images/modules/open_graph/github-logo.png">
+      <meta property="twitter:image:width" content="1200">
+      <meta property="twitter:image:height" content="1200">
+      <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+    <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+    <link rel="assets" href="https://assets-cdn.github.com/">
+    
+    <meta name="pjax-timeout" content="1000">
+    
+
+    <meta name="msapplication-TileImage" content="/windows-tile.png">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="selected-link" value="/" data-pjax-transient>
+
+    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+<meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-analytics" content="UA-3769691-2">
+
+<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="56F6086D:6DA3:DAF063:5736FF3C" name="octolytics-dimension-request_id" />
+
+
+
+
+  <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
+
+
+        <meta name="hostname" content="github.com">
+    <meta name="user-login" content="">
+
+        <meta name="expected-hostname" content="github.com">
+      <meta name="js-proxy-site-detection-payload" content="ODhkZjhmNTNiY2IyNjQyYjZkM2IwMWQyNmZiYTNhYmQ5OTMzM2IwOGI5NWRjMTU5MTQ5YjZiOGI5YjE0YzJkYXx7InJlbW90ZV9hZGRyZXNzIjoiODYuMjQ2LjguMTA5IiwicmVxdWVzdF9pZCI6IjU2RjYwODZEOjZEQTM6REFGMDYzOjU3MzZGRjNDIiwidGltZXN0YW1wIjoxNDYzMjIyMDc2fQ==">
+
+
+      <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#4078c0">
+      <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
+
+    <meta content="8d9e23ba9977ffec7be03eedd55f71796fdcfa3a" name="form-nonce" />
+
+    <meta http-equiv="x-pjax-version" content="a4cb11b734331d95088899b1377fb05e">
+    
+
+        <meta name="viewport" content="width=device-width">
+  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-c4b4365da282e51c06e107368db8502a2ecf82e64094d29d791b797372212de2.css" integrity="sha256-xLQ2XaKC5RwG4Qc2jbhQKi7PguZAlNKdeRt5c3IhLeI=" media="all" rel="stylesheet" />
+
+
+      <link rel="canonical" href="https://github.com/" data-pjax-transient>
+  </head>
+
+
+  <body class="logged-out   env-production linux  page-responsive">
+    <div id="js-pjax-loader-bar" class="pjax-loader-bar"></div>
+    <a href="#start-of-content" tabindex="1" class="accessibility-aid js-skip-to-content">Skip to content</a>
+
+    
+    
+    
+
+
+
+          <header class="site-header js-details-container" role="banner">
+  <div class="container-responsive">
+    <a class="header-logo-invertocat" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
+    </a>
+
+    <button class="btn-link right site-header-toggle js-details-target" type="button" aria-label="Toggle navigation">
+      <svg aria-hidden="true" class="octicon octicon-three-bars" height="24" version="1.1" viewBox="0 0 12 16" width="18"><path d="M11.41 9H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1z m0-4H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1zM0.59 11h10.81c0.59 0 0.59 0.41 0.59 1s0 1-0.59 1H0.59c-0.59 0-0.59-0.41-0.59-1s0-1 0.59-1z"></path></svg>
+    </button>
+
+    <div class="site-header-menu">
+      <nav class="site-header-nav site-header-nav-main">
+        <a href="/personal" class="js-selected-navigation-item nav-item nav-item-personal" data-ga-click="Header, click, Nav menu - item:personal" data-selected-links="/personal /personal">
+          Personal
+</a>        <a href="/open-source" class="js-selected-navigation-item nav-item nav-item-opensource" data-ga-click="Header, click, Nav menu - item:opensource" data-selected-links="/open-source /open-source">
+          Open source
+</a>        <a href="/business" class="js-selected-navigation-item nav-item nav-item-business" data-ga-click="Header, click, Nav menu - item:business" data-selected-links="/business /business/features /business/customers /business">
+          Business
+</a>        <a href="/explore" class="js-selected-navigation-item nav-item nav-item-explore" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship /explore">
+          Explore
+</a>      </nav>
+
+      <div class="site-header-actions">
+            <a class="btn btn-primary site-header-actions-btn" href="/join?source=header-home" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
+          <a class="btn site-header-actions-btn mr-2" href="/login" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
+      </div>
+
+        <nav class="site-header-nav site-header-nav-secondary">
+          <a class="nav-item" href="/pricing">Pricing</a>
+          <a class="nav-item" href="/blog">Blog</a>
+          <a class="nav-item" href="https://help.github.com">Support</a>
+          <a class="nav-item header-search-link" href="https://github.com/search">Search GitHub</a>
+              <div class="header-search   js-site-search" role="search">
+  <!-- </textarea> --><!-- '"` --><form accept-charset="UTF-8" action="/search" class="js-site-search-form" data-unscoped-search-url="/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+    <label class="form-control header-search-wrapper js-chromeless-input-container">
+      <div class="header-search-scope"></div>
+      <input type="text"
+        class="form-control header-search-input js-site-search-focus "
+        data-hotkey="s"
+        name="q"
+        placeholder="Search GitHub"
+        aria-label="Search GitHub"
+        data-unscoped-placeholder="Search GitHub"
+        data-scoped-placeholder="Search"
+        tabindex="1"
+        autocapitalize="off">
+    </label>
+</form></div>
+
+        </nav>
+    </div>
+  </div>
+</header>
+
+
+
+
+    <div id="start-of-content" class="accessibility-aid"></div>
+
+      <div id="js-flash-container">
+</div>
+
+
+    <div role="main" class="main-content">
+        
+<div class="jumbotron jumbotron-home jumbotron-inverse">
+  <div class="container-responsive">
+    <div class="columns">
+      <div class="homepage-hero-intro column">
+        <h1 class="display-heading-1 jumbotron-title">How&nbsp;people build&nbsp;software</h1>
+        <p class="display-intro jumbotron-lead">Millions of developers use GitHub to build personal projects, support their businesses, and&nbsp;work together on open source technologies.</p>
+      </div>
+      <div class="homepage-hero-signup column">
+          <div class="d-none-sm-dn">
+            <!-- </textarea> --><!-- '"` --><form accept-charset="UTF-8" action="/join" autocomplete="off" class="home-hero-signup js-signup-form" data-form-nonce="8d9e23ba9977ffec7be03eedd55f71796fdcfa3a" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="oNt3J87syD32TQ+TkbWCfbTNL3cJan96F4WfuYIZTsUXWKbtgxkc5Fk8iN6cKygoql2B2XLR6veSpPPG8FVqsw==" /></div>              <dl class="form">
+                <dd>
+                  <label class="form-label sr-only" for="user[login]">Pick a username</label>
+                  <input type="text" name="user[login]" class="form-control form-control-lg input-block" placeholder="Pick a username" data-autocheck-url="/signup_check/username" autofocus>
+                </dd>
+              </dl>
+              <dl class="form">
+                <dd>
+                  <label class="form-label sr-only" for="user[email]">Enter your email address</label>
+                  <input type="text" name="user[email]" class="form-control form-control-lg input-block js-email-notice-trigger" placeholder="Your email address" data-autocheck-url="/signup_check/email">
+                </dd>
+              </dl>
+              <dl class="form">
+                <dd>
+                  <label class="form-label sr-only" for="user[password]">Create a password</label>
+                  <input type="password" name="user[password]" class="form-control form-control-lg input-block" placeholder="Create a password" data-autocheck-url="/signup_check/password">
+                </dd>
+                <p class="form-control-note">Use at least one letter, one numeral, and seven characters.</p>
+              </dl>
+              <input type="hidden" name="source" class="js-signup-source" value="form-home">
+              <button class="btn btn-theme-green btn-jumbotron btn-block" type="submit">Sign up for GitHub</button>
+              <p class="form-control-note text-center">
+                By clicking "Sign up for GitHub", you agree to our
+                <a class="text-white" href="https://help.github.com/terms" target="_blank">terms of service</a> and
+                <a class="text-white" href="https://help.github.com/privacy" target="_blank">privacy policy</a>. <span class="js-email-notice">We'll occasionally send you account related emails.</span>
+              </p>
+</form>          </div>
+          <div class="d-none-md-up">
+            <a href="/join?source=button-home" class="btn btn-theme-green btn-jumbotron" rel="nofollow">Sign up for GitHub</a>
+          </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette bg-white py-5">
+  <div class="container-responsive">
+    <div class="columns">
+      <div class="one-third column">
+        <h3 class="display-heading-3" style="line-height: 1.2;">Introducing unlimited <br class="d-none-sm-dn">private&nbsp;repositories</h3>
+      </div>
+      <div class="two-thirds column">
+        <p class="mt-2 mb-0">All of our paid plans on GitHub.com now include unlimited private repositories. <a href="/join">Sign&nbsp;up</a>&nbsp;to get started or <a href="https://github.com/blog/2164-introducing-unlimited-private-repositories">read more about this change on our blog</a>.</p>
+        
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette pb-0 pt-6 shade-gray border-top">
+  <div class="container-responsive">
+    <h2 class="featurette-heading display-heading-2 mt-3 text-center">Welcome home, developers</h2>
+    <p class="featurette-lead featurette-lead-center display-intro mb-6 pb-4">GitHub fosters a fast, flexible, and collaborative development process that lets you work on your own or with others.</p>
+  </div>
+  <div class="tile-block">
+    <div class="tile-row">
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-build.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">For everything you build</h4>
+        <p class="display-body-sm">Host and manage your code on GitHub. You can keep your work private or share it with the world.</p>
+      </div>
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-work.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">A better way to work</h4>
+        <p class="display-body-sm">From hobbyists to professionals, GitHub helps developers simplify the way they build software.</p>
+      </div>
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-projects.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">Millions of projects</h4>
+        <p class="display-body-sm">GitHub is home to millions of open source projects. Try one out or get inspired to create your own.</p>
+      </div>
+      <div class="tile tile-bordered one-fourth text-center">
+        <img src="https://assets-cdn.github.com/images/modules/site/home-ill-platform.png?sn" alt="" class="img-responsive featurette-illo-sm mb-4 mt-4">
+        <h4 class="display-heading-4">One platform, from start to finish</h4>
+        <p class="display-body-sm">With hundreds of integrations, GitHub is flexible enough to be at the center of your development process.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette pb-0">
+  <div class="container-responsive">
+    <h2 class="display-heading-2">Who uses GitHub?</h2>
+    <hr class="triband-hr mt-5 mb-0">
+    <div class="columns">
+      <div class="one-third column my-4">
+        <h3 class="display-heading-3 mt-2"><a href="/personal" class="text-blue octicon-middle">Individuals <svg aria-hidden="true" class="octicon octicon-chevron-right" height="16" version="1.1" viewBox="0 0 8 16" width="8"><path d="M7.5 8L2.5 13l-1.5-1.5 3.75-3.5L1 4.5l1.5-1.5 5 5z"></path></svg></a></h3>
+        <p>Use GitHub to create a personal project, whether you want to experiment with a new programming language or host your life’s work.</p>
+      </div>
+      <div class="one-third column my-4">
+        <h3 class="display-heading-3 mt-2"><a href="/open-source" class="text-orange octicon-middle">Communities <svg aria-hidden="true" class="octicon octicon-chevron-right" height="16" version="1.1" viewBox="0 0 8 16" width="8"><path d="M7.5 8L2.5 13l-1.5-1.5 3.75-3.5L1 4.5l1.5-1.5 5 5z"></path></svg></a></h3>
+        <p>GitHub hosts one of the largest collections of open source software. Create, manage, and work on some of today’s most influential technologies.</p>
+      </div>
+      <div class="one-third column my-4">
+        <h3 class="display-heading-3 mt-2"><a href="/business" class="text-purple octicon-middle">Businesses <svg aria-hidden="true" class="octicon octicon-chevron-right" height="16" version="1.1" viewBox="0 0 8 16" width="8"><path d="M7.5 8L2.5 13l-1.5-1.5 3.75-3.5L1 4.5l1.5-1.5 5 5z"></path></svg></a></h3>
+        <p>Businesses of all sizes use GitHub to support their development process and securely build software.</p>
+      </div>
+    </div>
+    <hr class="triband-hr mt-0">
+    <div class="columns columns-vertically-centered columns-reverse mt-6">
+      <div class="one-third column">
+        <p class="display-body-sm">
+          GitHub is proud to host projects and organizations like <a href="//github.com/nasa">NASA</a>.
+        </p>
+      </div>
+      <div class="two-thirds column">
+        <img src="https://assets-cdn.github.com/images/modules/site/org_example_nasa.png?sn" class="img-responsive org-example-drop-shadow" alt="NASA is on GitHub">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="featurette shade-gradient pb-4">
+  <div class="container-responsive">
+    <div class="pricing-card pricing-card-horizontal">
+      <div class="pricing-card-cta">
+        <a href="/join?source=button-home" class="btn btn-block btn-theme-green btn-jumbotron" rel="nofollow">Sign up for GitHub</a>
+      </div>
+      <div class="pricing-card-text display-heading-3 mb-0 text-thin">
+          Public projects are always free. Work together across unlimited private repositories for $7 / month.
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div class="modal-backdrop"></div>
+
+    </div>
+
+        <div class="container site-footer-container">
+  <div class="site-footer" role="contentinfo">
+    <ul class="site-footer-links right">
+        <li><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
+      <li><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
+      <li><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
+      <li><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
+        <li><a href="https://github.com/blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
+        <li><a href="https://github.com/about" data-ga-click="Footer, go to about, text:about">About</a></li>
+
+    </ul>
+
+    <a href="https://github.com" aria-label="Homepage" class="site-footer-mark" title="GitHub">
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" version="1.1" viewBox="0 0 16 16" width="24"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z"></path></svg>
+</a>
+    <ul class="site-footer-links">
+      <li>&copy; 2016 <span title="0.01062s from github-fe154-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+        <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
+        <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
+        <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li><a href="https://github.com/contact" data-ga-click="Footer, go to contact, text:contact">Contact</a></li>
+        <li><a href="https://help.github.com" data-ga-click="Footer, go to help, text:help">Help</a></li>
+    </ul>
+  </div>
+</div>
+
+
+
+    
+
+    <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
+      <button type="button" class="flash-close js-flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+        <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
+      </button>
+      Something went wrong with that request. Please try again.
+    </div>
+
+
+      
+      <script crossorigin="anonymous" integrity="sha256-hR3lVUbYeteG8+/vO1Y0+PikDWf6bUT4VNnpl2fpyaI=" src="https://assets-cdn.github.com/assets/frameworks-851de55546d87ad786f3efef3b5634f8f8a40d67fa6d44f854d9e99767e9c9a2.js"></script>
+      <script async="async" crossorigin="anonymous" integrity="sha256-mm3jxdPdk82dZjim0bzCfrfL+a/dCCdx6pAPmZZZeiQ=" src="https://assets-cdn.github.com/assets/github-9a6de3c5d3dd93cd9d6638a6d1bcc27eb7cbf9afdd082771ea900f9996597a24.js"></script>
+      
+      
+      
+      
+      
+      
+    <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner hidden">
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M15.72 12.5l-6.85-11.98C8.69 0.21 8.36 0.02 8 0.02s-0.69 0.19-0.87 0.5l-6.85 11.98c-0.18 0.31-0.18 0.69 0 1C0.47 13.81 0.8 14 1.15 14h13.7c0.36 0 0.69-0.19 0.86-0.5S15.89 12.81 15.72 12.5zM9 12H7V10h2V12zM9 9H7V5h2V9z"></path></svg>
+      <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+      <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    </div>
+    <div class="facebox" id="facebox" style="display:none;">
+  <div class="facebox-popup">
+    <div class="facebox-content" role="dialog" aria-labelledby="facebox-header" aria-describedby="facebox-description">
+    </div>
+    <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
+      <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75-1.48-1.48 3.75-3.75L0.77 4.25l1.48-1.48 3.75 3.75 3.75-3.75 1.48 1.48-3.75 3.75z"></path></svg>
+    </button>
+  </div>
+</div>
+
+  </body>
+</html>
+

--- a/tests/test_reponses/twitter1.html
+++ b/tests/test_reponses/twitter1.html
@@ -1,0 +1,16033 @@
+<!DOCTYPE html>
+<!--[if IE 8]><html class="lt-ie10 ie8" lang="en" data-scribe-reduced-action-queue="true"><![endif]-->
+<!--[if IE 9]><html class="lt-ie10 ie9" lang="en" data-scribe-reduced-action-queue="true"><![endif]-->
+<!--[if gt IE 9]><!--><html lang="en" data-scribe-reduced-action-queue="true"><!--<![endif]-->
+  <head>
+    
+    
+    
+    
+    
+    
+    
+    <meta charset="utf-8">
+    
+    <noscript><meta http-equiv="refresh" content="0; URL=https://mobile.twitter.com/i/nojs_router?path=%2Fgithub"></noscript>
+    
+    
+  
+  <script id="bouncer_terminate_iframe" nonce="UKSg3Yzl9lx/mpOLeXQK+Q==">
+    if (window.top != window) {
+  window.top.postMessage({'bouncer': true, 'event': 'complete'}, '*');
+}
+  </script>
+  <script id="swift_action_queue" nonce="UKSg3Yzl9lx/mpOLeXQK+Q==">
+    (function(){function m(a){a||(a=window.event);if(!a)return!1;a.timestamp=(new Date).getTime();!a.target&&a.srcElement&&(a.target=a.srcElement);if(document.documentElement.getAttribute("data-scribe-reduced-action-queue")){var b=a.target;while(b&&b!=document
+.body){if(b.tagName=="A")return;b=b.parentNode}}r("all",s(a));if(!q(a)){r("direct",a);return!0}document.addEventListener||(a=s(a));a.preventDefault=a.stopPropagation=a.stopImmediatePropagation=function(){};if(i){f.push(a);r("captured",a)}else r("ignored",a
+);return!1}function n($){p();for(var a=0,b;b=f[a];a++){var d=$(b.target),e=d.closest("a")[0];if(b.type=="click"&&e){var g=$.data(e,"events"),i=g&&g.click,j=!e.hostname.match(c)||!e.href.match(/#$/);if(!i&&j){window.location=e.href;continue}}d.trigger($.event
+.fix(b))}window.swiftActionQueue.wasFlushed=!0}function o(){for(var a in j){if(a=="all")continue;var b=j[a];for(var c=0;c<b.length;c++)console.log("actionQueue",u(b[c]))}}function p(){clearTimeout(g);for(var a=0,b;b=e[a];a++)document["on"+b]=null}function q
+(a){if(!a.target)return!1;var b=a.target,e=(b.tagName||"").toLowerCase();if(a.metaKey)return!1;if(a.shiftKey&&e=="a")return!1;if(b.hostname&&!b.hostname.match(c))return!1;if(a.type.match(d)&&w(b))return!1;if(e=="label"){var f=b.getAttribute("for");if(f){var g=
+document.getElementById(f);if(g&&v(g))return!1}else for(var i=0,j;j=b.childNodes[i];i++)if(v(j))return!1}return!0}function r(a,b){b.bucket=a;j[a].push(b)}function s(a){var b={};for(var c in a)b[c]=a[c];return b}function t(a){while(a&&a!=document.body){if(a
+.tagName=="A")return a;a=a.parentNode}}function u(b){var c=[];b.bucket&&c.push("["+b.bucket+"]");c.push(b.type);var d=b.target,e=t(d),f="",g,i,j=b.timestamp&&b.timestamp-a;if(b.type==="click"&&e){g=e.className.trim().replace(/\s+/g,".");i=e.id.trim();f=/[^#]$/
+.test(e.href)?" ("+e.href+")":"";d='"'+e.innerText.replace(/\n+/g," ").trim()+'"'}else{g=d.className.trim().replace(/\s+/g,".");i=d.id.trim();d=d.tagName.toLowerCase();b.keyCode&&(d=String.fromCharCode(b.keyCode)+" : "+d)}c.push(d+f+(i&&"#"+i)+(!i&&g?"."+g
+:""));j&&c.push(j);return c.join(" ")}function v(a){var b=(a.tagName||"").toLowerCase();return b=="input"&&a.getAttribute("type")=="checkbox"}function w(a){var b=(a.tagName||"").toLowerCase();return b=="textarea"||b=="input"&&a.getAttribute("type")=="text"||
+a.getAttribute("contenteditable")=="true"}var a=(new Date).getTime(),b=1e4,c=/^([^\.]+\.)*twitter\.com$/,d=/^key/,e=["click","keydown","keypress","keyup"],f=[],g=null,i=!0,j={captured:[],ignored:[],direct:[],all:[]};for(var k=0,l;l=e[k];k++)document["on"+l
+]=m;g=setTimeout(function(){i=!1},b);window.swiftActionQueue={buckets:j,flush:n,logActions:o,wasFlushed:!1}})();
+  </script>
+  <script id="composition_state" nonce="UKSg3Yzl9lx/mpOLeXQK+Q==">
+    (function(){function a(a){a.target.setAttribute("data-in-composition","true")}function b(a){a.target.removeAttribute("data-in-composition")}if(document.addEventListener){document.addEventListener("compositionstart",a,!1);document.addEventListener("compositionend"
+,b,!1)}})();
+  </script>
+
+    <link rel="stylesheet" href="https://abs.twimg.com/a/1463112091/css/t1/twitter_core.bundle.css">
+  <link rel="stylesheet" href="https://abs.twimg.com/a/1463112091/css/t1/twitter_more_1.bundle.css">
+  <link rel="stylesheet" href="https://abs.twimg.com/a/1463112091/css/t1/twitter_more_2.bundle.css">
+
+    <link rel="dns-prefetch" href="https://pbs.twimg.com">
+    <link rel="dns-prefetch" href="https://t.co">
+      <link rel="preload" href="https://abs.twimg.com/c/swift/en/init.1c978d330d095c4fc1fa8dac83a9d2fa3c0ac53e.js" as="script">
+      <link rel="preload" href="https://abs.twimg.com/c/swift/en/bundle/timeline.6e2eac2c4e3ab6467a54813debdfa9061032bcd9.js" as="script">
+      <link rel="preload" href="https://abs.twimg.com/c/swift/en/bundle/boot.15a9fcfd58386ae29cdba949d3a146059b88ced4.js" as="script">
+
+      <title>GitHub (@github) | Twitter</title>
+      <meta name="robots" content="NOODP">
+  <meta name="description" content="The latest Tweets from GitHub (@github). How people build software. San Francisco, CA">
+
+
+
+<meta name="msapplication-TileImage" content="//abs.twimg.com/favicons/win8-tile-144.png"/>
+<meta name="msapplication-TileColor" content="#00aced"/>
+
+
+<link rel="mask-icon" sizes="any" href="https://abs.twimg.com/a/1463112091/img/t1/favicon.svg" color="#55acee">
+
+  <link href="//abs.twimg.com/favicons/favicon.ico" rel="shortcut icon" type="image/x-icon">
+
+<link rel="manifest" href="/manifest.json">
+
+
+  <meta name="swift-page-name" id="swift-page-name" content="profile">
+
+    <link rel="canonical" href="https://twitter.com/github">
+  <link rel="alternate" hreflang="x-default" href="https://twitter.com/github">
+  <link rel="alternate" hreflang="fr" href="https://twitter.com/github?lang=fr"><link rel="alternate" hreflang="en" href="https://twitter.com/github?lang=en"><link rel="alternate" hreflang="ar" href="https://twitter.com/github?lang=ar"><link rel="alternate" hreflang="ja" href="https://twitter.com/github?lang=ja"><link rel="alternate" hreflang="es" href="https://twitter.com/github?lang=es"><link rel="alternate" hreflang="de" href="https://twitter.com/github?lang=de"><link rel="alternate" hreflang="it" href="https://twitter.com/github?lang=it"><link rel="alternate" hreflang="id" href="https://twitter.com/github?lang=id"><link rel="alternate" hreflang="pt" href="https://twitter.com/github?lang=pt"><link rel="alternate" hreflang="ko" href="https://twitter.com/github?lang=ko"><link rel="alternate" hreflang="tr" href="https://twitter.com/github?lang=tr"><link rel="alternate" hreflang="ru" href="https://twitter.com/github?lang=ru"><link rel="alternate" hreflang="nl" href="https://twitter.com/github?lang=nl"><link rel="alternate" hreflang="fil" href="https://twitter.com/github?lang=fil"><link rel="alternate" hreflang="ms" href="https://twitter.com/github?lang=ms"><link rel="alternate" hreflang="zh-tw" href="https://twitter.com/github?lang=zh-tw"><link rel="alternate" hreflang="zh-cn" href="https://twitter.com/github?lang=zh-cn"><link rel="alternate" hreflang="hi" href="https://twitter.com/github?lang=hi"><link rel="alternate" hreflang="no" href="https://twitter.com/github?lang=no"><link rel="alternate" hreflang="sv" href="https://twitter.com/github?lang=sv"><link rel="alternate" hreflang="fi" href="https://twitter.com/github?lang=fi"><link rel="alternate" hreflang="da" href="https://twitter.com/github?lang=da"><link rel="alternate" hreflang="pl" href="https://twitter.com/github?lang=pl"><link rel="alternate" hreflang="hu" href="https://twitter.com/github?lang=hu"><link rel="alternate" hreflang="fa" href="https://twitter.com/github?lang=fa"><link rel="alternate" hreflang="he" href="https://twitter.com/github?lang=he"><link rel="alternate" hreflang="ur" href="https://twitter.com/github?lang=ur"><link rel="alternate" hreflang="th" href="https://twitter.com/github?lang=th"><link rel="alternate" hreflang="uk" href="https://twitter.com/github?lang=uk"><link rel="alternate" hreflang="ca" href="https://twitter.com/github?lang=ca"><link rel="alternate" hreflang="ga" href="https://twitter.com/github?lang=ga"><link rel="alternate" hreflang="el" href="https://twitter.com/github?lang=el"><link rel="alternate" hreflang="eu" href="https://twitter.com/github?lang=eu"><link rel="alternate" hreflang="cs" href="https://twitter.com/github?lang=cs"><link rel="alternate" hreflang="gl" href="https://twitter.com/github?lang=gl"><link rel="alternate" hreflang="ro" href="https://twitter.com/github?lang=ro"><link rel="alternate" hreflang="hr" href="https://twitter.com/github?lang=hr"><link rel="alternate" hreflang="en-gb" href="https://twitter.com/github?lang=en-gb"><link rel="alternate" hreflang="vi" href="https://twitter.com/github?lang=vi"><link rel="alternate" hreflang="bn" href="https://twitter.com/github?lang=bn"><link rel="alternate" hreflang="bg" href="https://twitter.com/github?lang=bg"><link rel="alternate" hreflang="sr" href="https://twitter.com/github?lang=sr"><link rel="alternate" hreflang="sk" href="https://twitter.com/github?lang=sk"><link rel="alternate" hreflang="gu" href="https://twitter.com/github?lang=gu"><link rel="alternate" hreflang="mr" href="https://twitter.com/github?lang=mr"><link rel="alternate" hreflang="ta" href="https://twitter.com/github?lang=ta"><link rel="alternate" hreflang="kn" href="https://twitter.com/github?lang=kn">
+
+
+  <link rel="alternate" media="handheld, only screen and (max-width: 640px)" href="https://mobile.twitter.com/github">
+
+      <link rel="alternate" href="android-app://com.twitter.android/twitter/user?screen_name=github&amp;ref_src=twsrc%5Egoogle%7Ctwcamp%5Eandroidseo%7Ctwgr%5Eprofile">
+
+<link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Twitter">
+
+    <link id="async-css-placeholder">
+
+      <input type="hidden" id="init-data" class="json-data" value="{&quot;permalinkOverlayEnabled&quot;:false,&quot;hasKenburnEffectOnSingleImage&quot;:false,&quot;maxTweetComposeCharacters&quot;:140,&quot;composeIgnoreAttachmentText&quot;:false,&quot;baseFoucClass&quot;:&quot;swift-loading&quot;,&quot;bodyFoucClassNames&quot;:&quot;swift-loading&quot;,&quot;macawSwift&quot;:true,&quot;assetsBasePath&quot;:&quot;https:\/\/abs.twimg.com\/a\/1463112091\/&quot;,&quot;assetVersionKey&quot;:&quot;c88735&quot;,&quot;environment&quot;:&quot;production&quot;,&quot;formAuthenticityToken&quot;:&quot;0ff51e342cbaed52729adbdd37fcab367da1e38f&quot;,&quot;loggedIn&quot;:false,&quot;screenName&quot;:null,&quot;fullName&quot;:null,&quot;userId&quot;:null,&quot;guestId&quot;:&quot;146323067541706309&quot;,&quot;allowAdsPersonalization&quot;:true,&quot;scribeBufferSize&quot;:3,&quot;pageName&quot;:&quot;profile&quot;,&quot;sectionName&quot;:&quot;profile&quot;,&quot;scribeParameters&quot;:{},&quot;recaptchaApiUrl&quot;:&quot;https:\/\/www.google.com\/recaptcha\/api\/js\/recaptcha_ajax.js&quot;,&quot;internalReferer&quot;:null,&quot;geoEnabled&quot;:false,&quot;typeaheadData&quot;:{&quot;accounts&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;limit&quot;:6},&quot;trendLocations&quot;:{&quot;enabled&quot;:true},&quot;dmConversations&quot;:{&quot;enabled&quot;:false},&quot;savedSearches&quot;:{&quot;enabled&quot;:false,&quot;items&quot;:[]},&quot;dmAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyDMable&quot;:true},&quot;mediaTagAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:true,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyShowUsersWithCanMediaTag&quot;:false,&quot;currentUserId&quot;:-1},&quot;selectedUsers&quot;:{&quot;enabled&quot;:false},&quot;prefillUsers&quot;:{&quot;enabled&quot;:false},&quot;topics&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:4},&quot;concierge&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:6},&quot;recentSearches&quot;:{&quot;enabled&quot;:false},&quot;hashtags&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500},&quot;useIndexedDB&quot;:false,&quot;showSearchAccountSocialContext&quot;:false,&quot;showDebugInfo&quot;:false,&quot;useThrottle&quot;:true,&quot;accountsOnTop&quot;:false,&quot;remoteDebounceInterval&quot;:300,&quot;remoteThrottleInterval&quot;:300,&quot;tweetContextEnabled&quot;:false,&quot;fullNameMatchingInCompose&quot;:true,&quot;topicsWithFiltersEnabled&quot;:false},&quot;dm&quot;:{&quot;notifications&quot;:false,&quot;usePushForNotifications&quot;:false,&quot;participant_max&quot;:50,&quot;video_gif_render&quot;:true,&quot;video_gif_upload&quot;:true,&quot;twitter_video_player&quot;:false,&quot;poll_options&quot;:{&quot;foreground_poll_interval&quot;:3000,&quot;burst_poll_interval&quot;:3000,&quot;burst_poll_duration&quot;:300000,&quot;max_poll_interval&quot;:60000}},&quot;whitelistedVideoUser&quot;:false,&quot;autoplayDisabled&quot;:false,&quot;pushStatePageLimit&quot;:500000,&quot;routes&quot;:{&quot;profile&quot;:&quot;\/&quot;},&quot;pushState&quot;:true,&quot;viewContainer&quot;:&quot;#page-container&quot;,&quot;dragAndDropPhotoUpload&quot;:true,&quot;href&quot;:&quot;\/github&quot;,&quot;searchPathWithQuery&quot;:&quot;\/search?q=query&amp;src=typd&quot;,&quot;timelineCardsGallery&quot;:true,&quot;composeAltText&quot;:false,&quot;deciders&quot;:{&quot;bulkUnfollowEnabled&quot;:true,&quot;custom_timeline_curation&quot;:false,&quot;moment_maker_enabled&quot;:false,&quot;disable_profile_popup&quot;:false,&quot;native_notifications&quot;:true,&quot;dm_polling_frequency_in_seconds&quot;:3000,&quot;enable_media_tag_prefetch&quot;:true,&quot;foundMediaTrendingEnabled&quot;:false,&quot;enableMacawNymizerConversionLanding&quot;:false,&quot;hqImageUploads&quot;:false,&quot;largeHeaderImageUpload&quot;:true,&quot;mqImageUploads&quot;:false,&quot;partnerIdSyncEnabled&quot;:true,&quot;sruMediaCategory&quot;:false,&quot;photoSruGifLimitMb&quot;:5,&quot;promoted_video_logging_enabled&quot;:true,&quot;pushState&quot;:true,&quot;scribeReducedActionQueue&quot;:true,&quot;smartInfiniteScroll&quot;:false,&quot;useHtml5Webcam&quot;:true,&quot;web_perftown_stats&quot;:true,&quot;web_perftown_ttft&quot;:true,&quot;web_sru_stats&quot;:false,&quot;web_upload_direct&quot;:true,&quot;web_upload_video&quot;:true,&quot;web_upload_video_advanced&quot;:false,&quot;upload_video_size&quot;:500,&quot;internationalShippingEnabled&quot;:true,&quot;useV2EndpointsEnabled&quot;:true,&quot;useVmapVariants&quot;:false,&quot;autoplayPreviewPreroll&quot;:true,&quot;moments_lohp_enabled&quot;:true,&quot;overlayPermalink&quot;:true,&quot;momentsExperienceEnabled&quot;:false,&quot;enableNativePush&quot;:false,&quot;installNativePush&quot;:false,&quot;autoSubscribeNativePush&quot;:false,&quot;composeLimits&quot;:{&quot;enabled&quot;:false,&quot;hashtags&quot;:50,&quot;mentions&quot;:50,&quot;links&quot;:10},&quot;stickersInteractivity&quot;:false,&quot;stickersInteractivityDuringLoading&quot;:false,&quot;stickersExperience&quot;:false,&quot;dynamic_video_ads_include_long_videos&quot;:true,&quot;push_state_size&quot;:1000},&quot;experiments&quot;:{},&quot;toasts_dm&quot;:false,&quot;toasts_spoonbill&quot;:false,&quot;toasts_timeline&quot;:false,&quot;toasts_dm_poll_scale&quot;:60,&quot;defaultNotificationIcon&quot;:&quot;https:\/\/abs.twimg.com\/a\/1463112091\/img\/t1\/mobile\/wp7_app_icon.png&quot;,&quot;uploadDomain&quot;:&quot;upload.twitter.com&quot;,&quot;promptbirdData&quot;:{&quot;promptbirdEnabled&quot;:false,&quot;immediateTriggers&quot;:[&quot;PullToRefresh&quot;,&quot;Navigate&quot;],&quot;format&quot;:&quot;ProfileOther&quot;},&quot;pageContext&quot;:&quot;profile&quot;,&quot;passwordResetAdvancedLoginForm&quot;:true,&quot;skipAutoSignupDialog&quot;:false,&quot;shouldReplaceSignupWithLogin&quot;:false,&quot;hashflagBaseUrl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/&quot;,&quot;activeHashflags&quot;:{&quot;أف_جيه&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;meinestimme&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;اقترعت&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;abematv&quot;:&quot;CyberAgentJapan\/AbemaTV.png&quot;,&quot;teamblake&quot;:&quot;TheVoice2016\/teamblake.png&quot;,&quot;bts&quot;:&quot;BTS\/BTS.png&quot;,&quot;أوريون&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;periscope&quot;:&quot;Periscope\/Periscope.png&quot;,&quot;thefalcon&quot;:&quot;CaptainAmericaCivilWar2\/TheFalcon.png&quot;,&quot;eurovision&quot;:&quot;eurovision2016\/Eurovision.png&quot;,&quot;timecapitãoamérica&quot;:&quot;DisneyMarvel\/TeamCap.png&quot;,&quot;frappuccinohappyhour&quot;:&quot;Starbucks2\/OriginalFile.png&quot;,&quot;lovetwitter&quot;:&quot;LoveTwitter\/LoveTwitter.png&quot;,&quot;teamironman&quot;:&quot;DisneyMarvel\/TeamIronman.png&quot;,&quot;تويوتا_السعودية&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;stanleycup&quot;:&quot;NHL\/StanleyCup.png&quot;,&quot;تويوتا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;ausvotes&quot;:&quot;AusVotes\/AusVotes.png&quot;,&quot;يارس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;ifoodsalva&quot;:&quot;iFood\/emoji_ifood_v2_final.png&quot;,&quot;كامري&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;방탄소년단&quot;:&quot;BTS\/BTS.png&quot;,&quot;hakkebakke&quot;:&quot;VodafoneFiles\/FinalEmoji.png&quot;,&quot;gameofthrones&quot;:&quot;GameofThrones\/GameofThrones.png&quot;,&quot;الأهلي&quot;:&quot;SaudiProfessionalLeague\/Al-Ahli.png&quot;,&quot;داينا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;hovotato&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;shakespeare400&quot;:&quot;Shakespeare400\/Shakespeare400.png&quot;,&quot;япроголосовал(а)&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;sienteelsabor&quot;:&quot;CocaCola\/SienteElSabor.png&quot;,&quot;راف_فور&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;teampharrell&quot;:&quot;TheVoice2016\/teampharrell.png&quot;,&quot;besuper&quot;:&quot;VodafoneFiles\/FinalEmoji.png&quot;,&quot;warmachine&quot;:&quot;CaptainAmericaCivilWar2\/WarMachine.png&quot;,&quot;hawkeye&quot;:&quot;CaptainAmericaCivilWar2\/Hawkeye.png&quot;,&quot;jaivoté&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;golive&quot;:&quot;goLIVE2016\/goLIVE.png&quot;,&quot;أفالون&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;laliga&quot;:&quot;LaLiga\/LaLiga.png&quot;,&quot;أفانزا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;我已投票&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;برادو&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;تويوتا_عبداللطيف_جميل&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;teamadam&quot;:&quot;TheVoice2016\/teamadam.png&quot;,&quot;thevision&quot;:&quot;CaptainAmericaCivilWar2\/TheVision.png&quot;,&quot;nouvellestar&quot;:&quot;NouvelleStar2016\/NouvelleStar.png&quot;,&quot;فورتشنر&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;fazerdiferente&quot;:&quot;TIM\/emoji_tim_final_3.png&quot;,&quot;كورولا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;هايلكس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;blackpanther&quot;:&quot;CaptainAmericaCivilWar2\/BlackPanther.png&quot;,&quot;estiempode&quot;:&quot;att-emoji2-assets\/attemoji2.png&quot;,&quot;كوستر&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;souflamengosoumaior&quot;:&quot;Flamengo\/Flamengo.png&quot;,&quot;antman&quot;:&quot;CaptainAmericaCivilWar2\/AntMan.png&quot;,&quot;إنوفا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;teamcap&quot;:&quot;DisneyMarvel\/TeamCap.png&quot;,&quot;투표했어요&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;spiderman&quot;:&quot;CaptainAmericaCivilWar2\/spiderman.png&quot;,&quot;rumoaorio&quot;:&quot;100Days\/100Days.png&quot;,&quot;لاندكروزر&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;bucky&quot;:&quot;CaptainAmericaCivilWar2\/WinterSoldierBucky.png&quot;,&quot;shakespearelives&quot;:&quot;Shakespeare400\/Shakespeare400.png&quot;,&quot;teamchristina&quot;:&quot;TheVoice2016\/teamxtina.png&quot;,&quot;تويوتا86&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;chamaolimpica&quot;:&quot;OlympicTorch_Emoji\/OlympicTorch.png&quot;,&quot;ivoted&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;teamxtina&quot;:&quot;TheVoice2016\/teamxtina.png&quot;,&quot;bandoironman&quot;:&quot;DisneyMarvel\/TeamIronman.png&quot;,&quot;الهلال&quot;:&quot;SaudiProfessionalLeague\/Al-Hilal.png&quot;,&quot;nsvote&quot;:&quot;NouvelleStar2016\/NSvote.png&quot;,&quot;olympicflame&quot;:&quot;OlympicTorch_Emoji\/OlympicTorch.png&quot;,&quot;timehomemdeferro&quot;:&quot;DisneyMarvel\/TeamIronman.png&quot;,&quot;desapega&quot;:&quot;olx\/emoji_olx_final.png&quot;,&quot;ograndvoltou&quot;:&quot;McDonalds\/emoji_mc_final.png&quot;,&quot;bandocapi&quot;:&quot;DisneyMarvel\/TeamCap.png&quot;,&quot;uncharted4&quot;:&quot;drake\/Drake.png&quot;,&quot;حزامك_أمانك&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;flamengo&quot;:&quot;Flamengo\/Flamengo.png&quot;,&quot;blackwidow&quot;:&quot;CaptainAmericaCivilWar2\/BlackWidow.png&quot;,&quot;بريوس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;keepdancing&quot;:&quot;KeepDancing\/KeepDancing.png&quot;,&quot;لاندكروزر_70&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;scarletwitch&quot;:&quot;CaptainAmericaCivilWar2\/ScarletWitch.png&quot;,&quot;الاهلي&quot;:&quot;SaudiProfessionalLeague\/Al-Ahli.png&quot;,&quot;thisishappening&quot;:&quot;KeepDancing\/KeepDancing.png&quot;,&quot;هايلوكس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;بريفيا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;wintersoldier&quot;:&quot;CaptainAmericaCivilWar2\/WinterSoldierBucky.png&quot;,&quot;timão&quot;:&quot;Corinthians\/Corinthians.png&quot;,&quot;لاندكروزر_مصندق&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;rumboario&quot;:&quot;100Days\/100Days.png&quot;,&quot;الاتحاد&quot;:&quot;SaudiProfessionalLeague\/Al-Ittihad.png&quot;,&quot;النصر&quot;:&quot;SaudiProfessionalLeague\/Al-Nassr.png&quot;,&quot;لاندكروزر_بيك_اب&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;yovoté&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;corinthians&quot;:&quot;Corinthians\/Corinthians.png&quot;,&quot;roadtorio&quot;:&quot;100Days\/100Days.png&quot;,&quot;عبداللطيف_جميل&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;icaucused&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;spidey&quot;:&quot;CaptainAmericaCivilWar2\/spiderman.png&quot;,&quot;سيكويا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;تويوتا_أكيد&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;frappuccino&quot;:&quot;Starbucks\/OriginalFile.png&quot;,&quot;amici15&quot;:&quot;amiciemojifiles\/amici_emoji.png&quot;,&quot;vaicorinthians&quot;:&quot;Corinthians\/Corinthians.png&quot;,&quot;omantoehmeu&quot;:&quot;Flamengo\/Flamengo.png&quot;,&quot;timao&quot;:&quot;Corinthians\/Corinthians.png&quot;},&quot;profile_user&quot;:{&quot;id&quot;:13334762,&quot;id_str&quot;:&quot;13334762&quot;,&quot;name&quot;:&quot;GitHub&quot;,&quot;screen_name&quot;:&quot;github&quot;,&quot;location&quot;:&quot;San Francisco, CA&quot;,&quot;url&quot;:&quot;https:\/\/github.com&quot;,&quot;description&quot;:&quot;How people build software&quot;,&quot;protected&quot;:false,&quot;followers_count&quot;:842686,&quot;friends_count&quot;:192,&quot;listed_count&quot;:12484,&quot;created_at&quot;:&quot;Mon Feb 11 04:41:50 +0000 2008&quot;,&quot;favourites_count&quot;:160,&quot;utc_offset&quot;:-25200,&quot;time_zone&quot;:&quot;Pacific Time (US &amp; Canada)&quot;,&quot;geo_enabled&quot;:true,&quot;verified&quot;:true,&quot;statuses_count&quot;:3230,&quot;lang&quot;:&quot;en&quot;,&quot;contributors_enabled&quot;:false,&quot;is_translator&quot;:false,&quot;is_translation_enabled&quot;:false,&quot;profile_background_color&quot;:&quot;EEEEEE&quot;,&quot;profile_background_image_url&quot;:&quot;http:\/\/pbs.twimg.com\/profile_background_images\/4229589\/header_bg.png&quot;,&quot;profile_background_image_url_https&quot;:&quot;https:\/\/pbs.twimg.com\/profile_background_images\/4229589\/header_bg.png&quot;,&quot;profile_background_tile&quot;:false,&quot;profile_image_url&quot;:&quot;http:\/\/pbs.twimg.com\/profile_images\/616309728688238592\/pBeeJQDQ_normal.png&quot;,&quot;profile_image_url_https&quot;:&quot;https:\/\/pbs.twimg.com\/profile_images\/616309728688238592\/pBeeJQDQ_normal.png&quot;,&quot;profile_banner_url&quot;:&quot;https:\/\/pbs.twimg.com\/profile_banners\/13334762\/1415719104&quot;,&quot;profile_link_color&quot;:&quot;0000FF&quot;,&quot;profile_sidebar_border_color&quot;:&quot;BBBBBB&quot;,&quot;profile_sidebar_fill_color&quot;:&quot;DDDDDD&quot;,&quot;profile_text_color&quot;:&quot;000000&quot;,&quot;profile_use_background_image&quot;:false,&quot;has_extended_profile&quot;:false,&quot;default_profile&quot;:false,&quot;default_profile_image&quot;:false,&quot;following&quot;:null,&quot;follow_request_sent&quot;:null,&quot;notifications&quot;:null,&quot;ext&quot;:{&quot;vine_profile&quot;:{&quot;r&quot;:{&quot;err&quot;:{&quot;code&quot;:202,&quot;message&quot;:&quot;You are not authorized to request this information.&quot;}},&quot;ttl&quot;:0}}},&quot;profileEditingCSSBundle&quot;:&quot;https:\/\/abs.twimg.com\/a\/1463112091\/css\/t1\/twitter_profile_editing.bundle.css&quot;,&quot;profile_id&quot;:13334762,&quot;businessProfile&quot;:false,&quot;cardsGallery&quot;:true,&quot;injectComposedTweets&quot;:false,&quot;help_pips_decider&quot;:false,&quot;inlineProfileEditing&quot;:false,&quot;forceHTML5FileUploader&quot;:false,&quot;isClusterFollowReplenishEnabled&quot;:false,&quot;autoplayEnabled&quot;:true,&quot;trendsCacheKey&quot;:null,&quot;decider_personalized_trends&quot;:false,&quot;trendsEndpoint&quot;:&quot;\/i\/trends&quot;,&quot;wtfOptions&quot;:{&quot;pc&quot;:false,&quot;connections&quot;:true,&quot;limit&quot;:3,&quot;display_location&quot;:&quot;profile-sidebar&quot;,&quot;dismissable&quot;:true,&quot;similar_to_user_id&quot;:13334762},&quot;showSensitiveContent&quot;:false,&quot;autoPlayBalloonsAnimation&quot;:false,&quot;isCurrentUser&quot;:false,&quot;timeline_url&quot;:&quot;\/i\/profiles\/show\/github\/timeline\/tweets&quot;,&quot;initialState&quot;:{&quot;title&quot;:&quot;GitHub (@github) | Twitter&quot;,&quot;section&quot;:null,&quot;module&quot;:&quot;app\/pages\/profile\/highline_landing&quot;,&quot;cache_ttl&quot;:300,&quot;body_class_names&quot;:&quot;three-col logged-out user-style-github enhanced-mini-profile ProfilePage ProfilePage--withBlockedWarning&quot;,&quot;doc_class_names&quot;:&quot;route-profile&quot;,&quot;route_name&quot;:&quot;profile&quot;,&quot;page_container_class_names&quot;:&quot;AppContent&quot;,&quot;ttft_navigation&quot;:false}}">
+
+  
+
+    <input type="hidden" class="swift-boot-module" value="app/pages/profile/highline_landing">
+  <input type="hidden" id="swift-module-path" value="https://abs.twimg.com/c/swift/en">
+
+  
+    <script src="https://abs.twimg.com/c/swift/en/init.1c978d330d095c4fc1fa8dac83a9d2fa3c0ac53e.js" async></script>
+
+  </head>
+  <body class="three-col logged-out user-style-github enhanced-mini-profile ProfilePage ProfilePage--withBlockedWarning" 
+data-fouc-class-names="swift-loading"
+ dir="ltr">
+      <script id="swift_loading_indicator" nonce="UKSg3Yzl9lx/mpOLeXQK+Q==">
+        document.body.className=document.body.className+" "+document.body.getAttribute("data-fouc-class-names");
+      </script>
+    <div id="doc" class="route-profile">
+        <div class="topbar js-topbar">
+
+
+  <div class="global-nav global-nav--newLoggedOut" data-section-term="top_nav">
+    <div class="global-nav-inner">
+      <div class="container">
+
+        
+<ul class="nav js-global-actions" role="navigation" id="global-actions">
+  <li id="global-nav-home" class="home" data-global-action="home">
+    <a class="js-nav js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/" data-component-context="home_nav" data-nav="home">
+      <span class="Icon Icon--bird Icon--large"></span>
+      <span class="text">Home</span>
+    </a>
+  </li>
+    <li id="global-nav-about" class="about" data-global-action="about">
+      <a class="js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/about" target="_blank" data-component-context="about_nav" data-nav="about">
+        <span class="text">About</span>
+      </a>
+    </li>
+</ul>
+<div class="pull-right">
+    <div role="search">
+  <form class="t1-form form-search js-search-form" action="/search" id="global-nav-search">
+    <label class="visuallyhidden" for="search-query">Search query</label>
+    <input class="search-input" type="text" id="search-query" placeholder="Search Twitter" name="q" autocomplete="off" spellcheck="false">
+    <span class="search-icon js-search-action">
+      <button type="submit" class="Icon Icon--search nav-search">
+        <span class="visuallyhidden">Search Twitter</span>
+      </button>
+    </span>
+      
+
+
+<div role="listbox" class="dropdown-menu typeahead">
+  <div aria-hidden="true" class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <div role="presentation" class="dropdown-inner js-typeahead-results">
+    <div role="presentation" class="typeahead-saved-searches">
+  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
+  <ul role="presentation" class="typeahead-items saved-searches-list">
+    
+    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
+      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
+      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+
+    <ul role="presentation" class="typeahead-items typeahead-topics">
+  
+  <li role="presentation" class="typeahead-item typeahead-topic-item">
+    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
+  </li>
+</ul>
+    
+
+
+<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+  
+  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+    
+    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+      <img class="avatar size32" alt="">
+      <span class="typeahead-user-item-info">
+        <span class="fullname"></span>
+        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+        <span class="username"><s>@</s><b></b></span>
+      </span>
+    </a>
+  </li>
+  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
+</ul>
+
+    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
+  
+  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
+</ul>
+    <div role="presentation" class="typeahead-user-select">
+  <div role="presentation" class="typeahead-empty-suggestions">
+    Suggested users
+  </div>
+  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-selected-end"></li>
+  </ul>
+
+  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-accounts-end"></li>
+  </ul>
+</div>
+
+    <div role="presentation" class="typeahead-dm-conversations">
+  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
+    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
+      <a role="option" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+  </div>
+</div>
+
+  </form>
+</div>
+
+
+  <ul class="nav secondary-nav language-dropdown">
+    <li class="dropdown js-language-dropdown">
+      <a href="#supported_languages" class="dropdown-toggle js-dropdown-toggle">
+        <small>Language:</small> <span class="js-current-language">English</span> <b class="caret"></b>
+      </a>
+      <div class="dropdown-menu">
+        <div class="dropdown-caret right">
+          <span class="caret-outer"> </span>
+          <span class="caret-inner"></span>
+        </div>
+        <ul id="supported_languages">
+            <li><a href="?lang=id" data-lang-code="id" title="Indonesian" class="js-language-link js-tooltip">Bahasa Indonesia</a></li>
+            <li><a href="?lang=msa" data-lang-code="msa" title="Malay" class="js-language-link js-tooltip">Bahasa Melayu</a></li>
+            <li><a href="?lang=ca" data-lang-code="ca" title="Catalan" class="js-language-link js-tooltip">Català</a></li>
+            <li><a href="?lang=cs" data-lang-code="cs" title="Czech" class="js-language-link js-tooltip">Čeština</a></li>
+            <li><a href="?lang=da" data-lang-code="da" title="Danish" class="js-language-link js-tooltip">Dansk</a></li>
+            <li><a href="?lang=de" data-lang-code="de" title="German" class="js-language-link js-tooltip">Deutsch</a></li>
+            <li><a href="?lang=en-gb" data-lang-code="en-gb" title="British English" class="js-language-link js-tooltip">English UK</a></li>
+            <li><a href="?lang=es" data-lang-code="es" title="Spanish" class="js-language-link js-tooltip">Español</a></li>
+            <li><a href="?lang=fil" data-lang-code="fil" title="Filipino" class="js-language-link js-tooltip">Filipino</a></li>
+            <li><a href="?lang=fr" data-lang-code="fr" title="French" class="js-language-link js-tooltip">Français</a></li>
+            <li><a href="?lang=hr" data-lang-code="hr" title="Croatian" class="js-language-link js-tooltip">Hrvatski</a></li>
+            <li><a href="?lang=it" data-lang-code="it" title="Italian" class="js-language-link js-tooltip">Italiano</a></li>
+            <li><a href="?lang=hu" data-lang-code="hu" title="Hungarian" class="js-language-link js-tooltip">Magyar</a></li>
+            <li><a href="?lang=nl" data-lang-code="nl" title="Dutch" class="js-language-link js-tooltip">Nederlands</a></li>
+            <li><a href="?lang=no" data-lang-code="no" title="Norwegian" class="js-language-link js-tooltip">Norsk</a></li>
+            <li><a href="?lang=pl" data-lang-code="pl" title="Polish" class="js-language-link js-tooltip">Polski</a></li>
+            <li><a href="?lang=pt" data-lang-code="pt" title="Portuguese" class="js-language-link js-tooltip">Português</a></li>
+            <li><a href="?lang=ro" data-lang-code="ro" title="Romanian" class="js-language-link js-tooltip">Română</a></li>
+            <li><a href="?lang=sk" data-lang-code="sk" title="Slovak" class="js-language-link js-tooltip">Slovenčina</a></li>
+            <li><a href="?lang=fi" data-lang-code="fi" title="Finnish" class="js-language-link js-tooltip">Suomi</a></li>
+            <li><a href="?lang=sv" data-lang-code="sv" title="Swedish" class="js-language-link js-tooltip">Svenska</a></li>
+            <li><a href="?lang=vi" data-lang-code="vi" title="Vietnamese" class="js-language-link js-tooltip">Tiếng Việt</a></li>
+            <li><a href="?lang=tr" data-lang-code="tr" title="Turkish" class="js-language-link js-tooltip">Türkçe</a></li>
+            <li><a href="?lang=el" data-lang-code="el" title="Greek" class="js-language-link js-tooltip">Ελληνικά</a></li>
+            <li><a href="?lang=bg" data-lang-code="bg" title="Bulgarian" class="js-language-link js-tooltip">Български език</a></li>
+            <li><a href="?lang=ru" data-lang-code="ru" title="Russian" class="js-language-link js-tooltip">Русский</a></li>
+            <li><a href="?lang=sr" data-lang-code="sr" title="Serbian" class="js-language-link js-tooltip">Српски</a></li>
+            <li><a href="?lang=uk" data-lang-code="uk" title="Ukrainian" class="js-language-link js-tooltip">Українська мова</a></li>
+            <li><a href="?lang=he" data-lang-code="he" title="Hebrew" class="js-language-link js-tooltip">עִבְרִית</a></li>
+            <li><a href="?lang=ar" data-lang-code="ar" title="Arabic" class="js-language-link js-tooltip">العربية</a></li>
+            <li><a href="?lang=fa" data-lang-code="fa" title="Persian" class="js-language-link js-tooltip">فارسی</a></li>
+            <li><a href="?lang=mr" data-lang-code="mr" title="Marathi" class="js-language-link js-tooltip">मराठी</a></li>
+            <li><a href="?lang=hi" data-lang-code="hi" title="Hindi" class="js-language-link js-tooltip">हिन्दी</a></li>
+            <li><a href="?lang=bn" data-lang-code="bn" title="Bengali" class="js-language-link js-tooltip">বাংলা</a></li>
+            <li><a href="?lang=gu" data-lang-code="gu" title="Gujarati" class="js-language-link js-tooltip">ગુજરાતી</a></li>
+            <li><a href="?lang=ta" data-lang-code="ta" title="Tamil" class="js-language-link js-tooltip">தமிழ்</a></li>
+            <li><a href="?lang=kn" data-lang-code="kn" title="Kannada" class="js-language-link js-tooltip">ಕನ್ನಡ</a></li>
+            <li><a href="?lang=th" data-lang-code="th" title="Thai" class="js-language-link js-tooltip">ภาษาไทย</a></li>
+            <li><a href="?lang=ko" data-lang-code="ko" title="Korean" class="js-language-link js-tooltip">한국어</a></li>
+            <li><a href="?lang=ja" data-lang-code="ja" title="Japanese" class="js-language-link js-tooltip">日本語</a></li>
+            <li><a href="?lang=zh-cn" data-lang-code="zh-cn" title="Simplified Chinese" class="js-language-link js-tooltip">简体中文</a></li>
+            <li><a href="?lang=zh-tw" data-lang-code="zh-tw" title="Traditional Chinese" class="js-language-link js-tooltip">繁體中文</a></li>
+        </ul>
+      </div>
+      <div class="js-front-language">
+        <form action="/sessions/change_locale" class="t1-form language" method="POST">
+          <input type="hidden" name="lang"> <input type="hidden" name="redirect">
+          <input type="hidden" name="authenticity_token" value="0ff51e342cbaed52729adbdd37fcab367da1e38f">
+        </form>
+      </div>
+    </li>
+  </ul>
+
+    <ul class="nav secondary-nav session-dropdown" id="session">
+      <li class="dropdown js-session">
+          <a href="/login" class="dropdown-toggle js-dropdown-toggle dropdown-signin" id="signin-link" data-nav="login">
+            <small>Have an account?</small> <span class="emphasize"> Log in</span><span class="caret"></span>
+          </a>
+          <div class="dropdown-menu dropdown-form" id="signin-dropdown">
+            <div class="dropdown-caret right"> <span class="caret-outer"></span> <span class="caret-inner"></span> </div>
+            <div class="signin-dialog-body">
+              <div>Have an account?</div>
+              <form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
+  data-component="login_callout"
+  data-element="form"
+>
+  <div class="LoginForm-input LoginForm-username">
+    <input
+      type="text"
+      class="text-input email-input js-signin-email"
+      name="session[username_or_email]"
+      autocomplete="username"
+      placeholder="Phone, email or username"
+    />
+  </div>
+
+  <div class="LoginForm-input LoginForm-password">
+    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
+  </div>
+
+  <div class="LoginForm-rememberForgot">
+    <label>
+      <input type="checkbox" value="1" name="remember_me" checked="checked">
+      <span>Remember me</span>
+    </label>
+    <span class="separator">&middot;</span>
+    <a class="forgot" href="/account/begin_password_reset">Forgot password?</a>
+  </div>
+
+  <input type="submit" class="submit btn primary-btn js-submit" value="Log in">
+
+    <input type="hidden" name="return_to_ssl" value="true">
+
+  <input type="hidden" name="scribe_log">
+  <input type="hidden" name="redirect_after_login" value="/github">
+  <input type="hidden" value="0ff51e342cbaed52729adbdd37fcab367da1e38f" name="authenticity_token">
+</form>
+
+              <hr>
+              <div class="signup SignupForm">
+                <div class="SignupForm-header">New to Twitter?</div>
+                <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn"
+                  data-component="signup_callout"
+                  data-element="dropdown"
+                  >Sign up
+                </a>
+              </div>
+            </div>
+          </div>
+      </li>
+    </ul>
+</div>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+
+        <div id="page-outer">
+          <div id="page-container" class="AppContent">
+              
+            
+
+
+      
+<style id="user-style-github">
+
+
+
+
+
+  a,
+  a:hover,
+  a:focus,
+  a:active {
+    color: #0000FF;
+  }
+
+  .u-textUserColor,
+  .u-textUserColorHover:hover,
+  .u-textUserColorHover:focus {
+    color: #0000FF !important;
+  }
+
+  .u-borderUserColor,
+  .u-borderUserColorHover:hover,
+  .u-borderUserColorHover:focus {
+    border-color: #0000FF !important;
+  }
+
+  .u-bgUserColor,
+  .u-bgUserColorHover:hover,
+  .u-bgUserColorHover:focus {
+    background-color: #0000FF !important;
+  }
+
+
+  .u-dropdownUserColor > li:hover,
+  .u-dropdownUserColor > li:focus,
+  .u-dropdownUserColor > li > button:hover,
+  .u-dropdownUserColor > li > button:focus {
+    color: #fff !important;
+    background-color: #0000FF !important;
+  }
+
+  .u-boxShadowInsetUserColorHover:hover,
+  .u-boxShadowInsetUserColorHover:focus {
+    box-shadow: inset 0 0 0 5px #0000FF !important;
+  }
+
+
+
+  .u-textUserColorLight {
+    color: #9999FF !important;
+  }
+
+  .u-borderUserColorLight,
+  .u-borderUserColorLightFocus:focus,
+  .u-borderUserColorLightHover:hover,
+  .u-borderUserColorLightHover:focus {
+    border-color: #9999FF !important;
+  }
+
+  .u-bgUserColorLight {
+    background-color: #9999FF !important;
+  }
+
+
+  .u-boxShadowUserColorLighterFocus:focus {
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.05), inset 0 1px 2px rgba(0,0,255,0.25) !important;
+  }
+
+
+  .u-textUserColorLightest {
+    color: #E5E5FF !important;
+  }
+
+  .u-borderUserColorLightest {
+    border-color: #E5E5FF !important;
+  }
+
+  .u-bgUserColorLightest {
+    background-color: #E5E5FF !important;
+  }
+
+
+  .u-textUserColorLighter {
+    color: #BFBFFF !important;
+  }
+
+  .u-borderUserColorLighter {
+    border-color: #BFBFFF !important;
+  }
+
+  .u-bgUserColorLighter {
+    background-color: #BFBFFF !important;
+  }
+
+
+  .u-bgUserColorDarkHover:hover {
+    background-color: #0000CC !important;
+  }
+
+  .u-borderUserColorDark {
+    border-color: #0000CC !important;
+  }
+
+
+  .u-bgUserColorDarkerActive:active {
+    background-color: #000099 !important;
+  }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+a,
+.btn-link,
+.btn-link:focus,
+.icon-btn,
+
+
+
+.pretty-link b,
+.pretty-link:hover s,
+.pretty-link:hover b,
+.pretty-link:focus s,
+.pretty-link:focus b,
+/* Account Group */
+.metadata a:hover,
+.metadata a:focus,
+
+.account-group:hover .fullname,
+.account-group:focus .fullname,
+.account-summary:focus .fullname,
+
+.message .message-text a,
+.stats a strong,
+.plain-btn:hover,
+.plain-btn:focus,
+.dropdown.open .user-dropdown.plain-btn,
+.open > .plain-btn,
+#global-actions .new:before,
+.module .list-link:hover,
+.module .list-link:focus,
+
+.stats a:hover,
+.stats a:hover strong,
+.stats a:focus,
+.stats a:focus strong,
+
+.profile-modal-header .fullname a:hover,
+.profile-modal-header .username a:hover,
+.profile-modal-header .fullname a:focus,
+.profile-modal-header .username a:focus,
+
+.find-friends-sources li:hover .source,
+
+
+
+
+
+.stream-item a:hover .fullname,
+.stream-item a:focus .fullname,
+
+.stream-item .view-all-supplements:hover,
+.stream-item .view-all-supplements:focus,
+
+.tweet .time a:hover,
+.tweet .time a:focus,
+.tweet .details.with-icn b,
+.tweet .details.with-icn .Icon,
+.tweet .tweet-geo-text a:hover,
+
+.stream-item:hover .original-tweet .details b,
+.stream-item .original-tweet.focus .details b,
+.stream-item.open .original-tweet .details b,
+
+.client-and-actions a:hover,
+.client-and-actions a:focus,
+
+.dismiss-btn:hover b,
+
+.tweet .context .pretty-link:hover s,
+.tweet .context .pretty-link:hover b,
+.tweet .context .pretty-link:focus s,
+.tweet .context .pretty-link:focus b,
+
+.list .username a:hover,
+.list .username a:focus,
+.list-membership-container .create-a-list,
+.list-membership-container .create-a-list:hover,
+
+
+
+.card .list-details a:hover,
+.card .list-details a:focus,
+.card .card-body:hover .attribution,
+.card .card-body .attribution:focus,
+.new-tweets-bar,
+.onebox .soccer ul.ticker a:hover,
+.onebox .soccer ul.ticker a:focus,
+
+
+
+.remove-background-btn,
+
+
+
+.stream-item-activity-notification .latest-tweet .tweet-row a:hover,
+.stream-item-activity-notification .latest-tweet .tweet-row a:focus,
+.stream-item-activity-notification .latest-tweet .tweet-row a:hover b,
+.stream-item-activity-notification .latest-tweet .tweet-row a:focus b {
+    color: #0000FF;
+}
+
+
+
+
+  /* hover state for found media items */
+  .FoundMediaSearch--keyboard .FoundMediaSearch-focusable.is-focused {
+    border-color: #0000FF;
+  }
+
+  /* hover state for photo select button*/
+  .photo-selector:hover .btn,
+  .icon-btn:hover,
+  .icon-btn:active,
+  .icon-btn.active,
+  .icon-btn.enabled {
+    border-color: #0000FF;
+    border-color: rgba(0,0,255,.5);
+    color: #0000FF;
+  }
+
+  /* hover state for photo select button*/
+  .photo-selector:hover .btn,
+  .icon-btn:hover {
+    background-image: linear-gradient(rgba(255,255,255,0), rgba(0,0,255,.1));
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00FFFFFF', endColorstr='#190000FF'); /* IE8-9 */
+  }
+
+  .icon-btn.disabled,
+  .icon-btn.disabled:hover,
+  .icon-btn[disabled],
+  .icon-btn[aria-disabled=true] {
+    color: #0000FF;
+  }
+
+  /* tweet-btn can have primary-btn class as well so the following rules ensure that the correct background color is applied */
+  .tweet-btn,
+  .tweet-btn:focus {
+    background-color: #0000FF;
+    background: rgba(0,0,255,.8);
+  }
+
+  .tweet-btn:hover,
+  .tweet-btn:active,
+  .tweet-btn.active {
+    background-color: #0000FF;
+  }
+
+  .tweet-btn.btn.disabled,
+  .tweet-btn.btn.disabled:hover,
+  .tweet-btn.btn[disabled],
+  .tweet-btn.btn[aria-disabled=true] {
+    background: #0000FF;
+  }
+
+  .btn:focus,
+  .btn.focus,
+  .Button:focus {
+    box-shadow:
+      0 0 0 1px #fff,
+      0 0 0 3px rgba(0, 0, 255, 0.5);
+  }
+
+  .selected-stream-item:focus {
+    box-shadow: 0 0 0 3px rgba(0, 0, 255, 0.5);
+  }
+
+  /* highlighting when navigate through timeline stream table view with j & k. */
+  .js-navigable-stream.stream-table-view .selected-stream-item[tabindex="-1"]:focus {
+    outline: 3px solid rgba(0, 0, 255, 0.5) !important;
+  }
+
+  /* box-shadow does not work with table tr element */
+  .js-navigable-stream.stream-table-view .selected-stream-item:focus {
+    box-shadow: none;
+  }
+
+  /**
+   * 1. Bring actionable tweet to top when active to ensure border
+   *    highlighting wraps entire tweet. Value must be at least at if not
+   *    higher than the z-index value of ProfileHeading to ensure first
+   *    tweet in timeline receives border on all four sides.
+   *    NOTE: z-index should be 2 to avoid conflicts with .ProfileCanopy and .ProfileCard-avatarLink
+   */
+
+  .js-stream-item.is-selected:focus .ProfileCard,
+  .QuoteTweet:hover,
+  .QuoteTweet:focus,
+  .QuoteTweet:active,
+  .activity-user-profile-content:hover,
+  .activity-user-profile-content:focus,
+  .activity-user-profile-content:active {
+    border-color: rgba(0, 0, 255, 0.5);
+    z-index: 2; /* 1 */
+  }
+
+  .global-dm-nav.new.with-count .dm-new {
+    background: #fff;
+  }
+
+  .global-dm-nav.new.with-count .dm-new .count-inner {
+    background: #0000FF;
+  }
+
+  .global-nav .people .count .count-inner {
+    background: #0000FF;
+  }
+
+  .dropdown-menu li > a:hover,
+  .dropdown-menu li > a:focus,
+  .dropdown-menu .dropdown-link:hover,
+  .dropdown-menu .dropdown-link:focus,
+  .dropdown-menu .dropdown-link.is-focused,
+  .dropdown-menu li:hover .dropdown-link,
+  .dropdown-menu li:focus .dropdown-link,
+  .dropdown-menu .typeahead-recent-search-item.selected,
+  .dropdown-menu .typeahead-saved-search-item.selected,
+  .dropdown-menu .selected a,
+  .dropdown-menu .dropdown-link.selected {
+    background-color: #0000FF !important;
+  }
+
+/* give tweet boxes 10% of the users link color as background */
+.home-tweet-box,
+.RetweetDialog-commentBox,
+.WebToast-box--altColor,
+.content-main .conversations-enabled .expansion-container .inline-reply-tweetbox {
+  background-color: #E5E5FF;
+}
+
+.conversations-enabled .inline-reply-caret .caret-inner {
+  border-bottom-color: #E5E5FF;
+}
+.top-timeline-tweetbox .timeline-tweet-box .tweet-form.condensed .tweet-box {
+  color: #0000FF;
+}
+/* give tweet box containers an outline using the users link color */
+.RichEditor {
+  border-color: #BFBFFF;
+}
+/* give tweet boxes an outline using the users link color */
+.tweet-compose-errors {
+  border-color: rgba(0,0,255,0.25);
+}
+
+input:focus,
+textarea:focus,
+div[contenteditable="true"]:focus,
+div[contenteditable="true"].fake-focus {
+  border-color: #6666FF;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 255, 0.7);
+}
+
+.tweet-box textarea:focus,
+.tweet-box input[type=text],
+.currently-dragging .tweet-form.is-droppable .tweet-drag-help,
+.tweet-box[contenteditable="true"]:focus,
+.RichEditor.is-fakeFocus {
+  border-color: #9999FF;
+  box-shadow: none;
+}
+
+
+
+
+s,
+.pretty-link:hover s,
+.pretty-link:focus s,
+.stream-item-activity-notification .latest-tweet .tweet-row a:hover s,
+.stream-item-activity-notification .latest-tweet .tweet-row a:focus s {
+    color: #0000FF;
+}
+
+
+
+.vellip,
+.vellip:before,
+.vellip:after,
+.conversation-module > li:after,
+.conversation-module > li:before,
+.ThreadedConversation-tweet ~ .ThreadedConversation-tweet:before,
+.ThreadedConversation-tweet:after,
+.ThreadedConversation-viewOther:before,
+.ThreadedConversation-unavailableTweet:before,
+.ThreadedConversation-unavailableTweet:after {
+    background-color: #6666FF;
+}
+
+
+
+
+.tweet .sm-reply,
+.tweet .sm-rt,
+.tweet .sm-fav,
+.tweet .sm-image,
+.tweet .sm-video,
+.tweet .sm-audio,
+.tweet .sm-geo,
+.tweet .sm-in,
+.tweet .sm-trash,
+.tweet .sm-more,
+.tweet .sm-page,
+.tweet .sm-embed,
+.tweet .sm-summary,
+.tweet .sm-chat,
+
+.timelines-navigation .active .profile-nav-icon,
+.timelines-navigation .profile-nav-icon:hover,
+.timelines-navigation .profile-nav-link:focus .profile-nav-icon,
+
+.sm-top-tweet,
+
+.metadata a.tweet-geo-text:hover .sm-geo {
+    background-color: #0000FF;
+}
+
+.enhanced-mini-profile .mini-profile .profile-summary {
+  background-image: url(https://pbs.twimg.com/profile_banners/13334762/1415719104/mobile);
+}
+
+.wrapper-profile .profile-card.profile-header .profile-header-inner {
+  background-image: url(https://pbs.twimg.com/profile_banners/13334762/1415719104/web);
+}
+
+  #global-tweet-dialog .modal-header {
+    border-bottom: solid 1px rgba(0, 0, 255, .25);
+  }
+
+  #global-tweet-dialog .modal-tweet-form-container {
+    background-color: #0000FF;
+    background: rgba(0, 0, 255, .1);
+  }
+
+  .inline-reply-tweetbox {
+    background-color: #E5E5FF;
+  }
+
+</style>
+
+
+    <div class="ProfileCanopy ProfileCanopy--withNav ProfileCanopy--large">
+  <div class="ProfileCanopy-inner">
+
+    <div class="ProfileCanopy-header u-bgUserColor">
+    <div class="ProfileCanopy-headerBg">
+      <img alt=""
+        src="https://pbs.twimg.com/profile_banners/13334762/1415719104/1500x500"
+        
+      >
+    </div>
+
+  <div class="AppContainer">
+
+    <div class="ProfileCanopy-avatar">
+      <div class="ProfileAvatar">
+    <a class="ProfileAvatar-container u-block js-tooltip profile-picture"
+        href="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+        title="GitHub"
+        data-resolved-url-large="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+        data-url="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+        target="_blank">
+      <img class="ProfileAvatar-image " src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_400x400.png" alt="GitHub">
+    </a>
+</div>
+
+    </div>
+
+
+    <div class="ProfileCanopy-headerPromptAnchor"></div>
+  </div>
+
+</div>
+
+
+    <div class="ProfileCanopy-navBar">
+      
+      <div class="AppContainer">
+        <div class="Grid Grid--withGutter">
+          <div class="Grid-cell u-size1of3 u-lg-size1of4">
+            <div class="ProfileCanopy-card" role="presentation">
+              <div class="ProfileCardMini">
+  <a class="ProfileCardMini-avatar profile-picture js-tooltip"
+     href="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+     title="GitHub"
+     data-resolved-url-large="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+     data-url="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+     target="_blank">
+    <img class="ProfileCardMini-avatarImage" alt="GitHub" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_normal.png" >
+  </a>
+  <div class="ProfileCardMini-details">
+    <div class="ProfileNameTruncated">
+  <div class="u-textTruncate u-inlineBlock ProfileNameTruncated-withBadges ProfileNameTruncated-withBadges--1">
+    <a class="ProfileNameTruncated-link u-textInheritColor js-nav js-action-profile-name" href="/github"  data-aria-label-part>
+      GitHub
+    </a>
+      <div class="ProfileNameTruncated-badges">
+        <a href="/help/verified" class="js-tooltip" target="_blank" title="Verified account" data-placement="right"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></a>
+
+      </div>
+  </div>
+</div>
+    <div class="ProfileCardMini-screenname">
+      <a href="/github" class="ProfileCardMini-screennameLink u-linkComplex js-nav u-dir" dir="ltr">@<span class="u-linkComplex-target">github</span></a>
+    </div>
+  </div>
+</div>
+
+            </div>
+          </div>
+
+          <div class="Grid-cell u-size2of3 u-lg-size3of4">
+            <div class="ProfileCanopy-nav">
+              
+  <div class="ProfileNav" role="navigation" data-user-id="13334762">
+    <ul class="ProfileNav-list">
+<li class="ProfileNav-item ProfileNav-item--tweets is-active">
+          <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-nav" title="3,230 Tweets" data-nav="tweets"
+              tabindex=0
+>
+            <span class="ProfileNav-label">Tweets</span>
+            <span class="ProfileNav-value" data-is-compact="false">3,230</span>
+          </a>
+        </li><li class="ProfileNav-item ProfileNav-item--following">
+        <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-openSignupDialog js-nonNavigable u-textUserColor" title="192 Following" data-nav="following"
+            href="/github/following"
+>
+          <span class="ProfileNav-label">Following</span>
+          <span class="ProfileNav-value" data-is-compact="false">192</span>
+        </a>
+      </li><li class="ProfileNav-item ProfileNav-item--followers">
+        <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-openSignupDialog js-nonNavigable u-textUserColor" title="842,686 Followers" data-nav="followers"
+            href="/github/followers"
+>
+          <span class="ProfileNav-label">Followers</span>
+          <span class="ProfileNav-value" data-is-compact="true">843K</span>
+        </a>
+      </li><li class="ProfileNav-item ProfileNav-item--favorites" data-more-item=".ProfileNav-dropdownItem--favorites">
+        <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-openSignupDialog js-nonNavigable u-textUserColor" title="160 Likes" data-nav="favorites"
+            href="/github/likes"
+>
+          <span class="ProfileNav-label">Likes</span>
+          <span class="ProfileNav-value" data-is-compact="false">160</span>
+        </a>
+      </li><li class="ProfileNav-item ProfileNav-item--more dropdown is-hidden">        <a class="ProfileNav-stat ProfileNav-stat--link ProfileNav-stat--moreLink js-openSignupDialog js-nonNavigable" href="#more">
+          <span class="ProfileNav-label">&nbsp;</span>
+          <span class="ProfileNav-value">More <span class="ProfileNav-dropdownCaret Icon Icon--caretDown"></span></span>
+        </a>
+        <div class="dropdown-menu">
+          <div class="dropdown-caret">
+            <span class="caret-outer"></span>
+            <span class="caret-inner"></span>
+          </div>
+          <ul><li>
+              <a href="/github/likes" class="ProfileNav-dropdownItem ProfileNav-dropdownItem--favorites is-hidden u-bgUserColorHover u-bgUserColorFocus u-linkClean js-nav">Likes</a></li></ul>
+        </div>
+      </li><li class="ProfileNav-item ProfileNav-item--userActions u-floatRight u-textRight with-rightCaret ">
+        <div class="UserActions   u-textLeft" >
+    <div class="user-actions btn-group not-following " data-user-id="13334762"
+        data-screen-name="github" data-name="GitHub" data-protected="false">
+      <span class="UserActions-moreActions u-inlineBlock">
+          <button type="button" class="js-tooltip unmute-button btn small plain-btn" title="Unmute @github" data-placement="top">
+            <span class="Icon Icon--muted Icon--medium"><span class="visuallyhidden">Unmute @github</span></span>
+          </button><button type="button" class="first-load js-tooltip mute-button btn small plain-btn" title="Mute @github" data-placement="top">
+            <span class="Icon Icon--unmuted Icon--medium"><span class="visuallyhidden">Mute @github</span></span>
+          </button>
+
+      </span><button class="user-actions-follow-button js-follow-btn follow-button btn" type="button">
+  <span class="button-text follow-text">
+     <span class="Icon Icon--follow"></span> Follow 
+    
+  </span>
+  <span class="button-text following-text">
+     Following 
+    
+  </span>
+  <span class="button-text unfollow-text">
+     Unfollow 
+    
+  </span>
+  <span class="button-text blocked-text">Blocked</span>
+  <span class="button-text unblock-text">Unblock</span>
+  <span class="button-text pending-text">Pending</span>
+  <span class="button-text cancel-text">Cancel</span>
+</button>
+
+    </div>
+</div>
+
+      </li>
+    </ul>
+  </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+
+
+    <div class="AppContainer">
+      <div class="AppContent-main content-main u-cf" role="main" aria-labelledby="content-main-heading">
+        <div class="Grid Grid--withGutter">
+          <div class="Grid-cell u-size1of3 u-lg-size1of4">
+            <div class="Grid Grid--withGutter">
+              <div class="Grid-cell">
+                <div class="ProfileSidebar ProfileSidebar--withLeftAlignment">
+  <div class="ProfileHeaderCard">
+  <h1 class="ProfileHeaderCard-name">
+    <a href="/github"
+       class="ProfileHeaderCard-nameLink u-textInheritColor js-nav
+         ProfileHeaderCard-nameWithBadges--1
+">GitHub</a><span class="ProfileHeaderCard-badges ProfileHeaderCard-badges--1"><a href="/help/verified" class="js-tooltip" target="_blank" title="Verified account" data-placement="right"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></a>
+</span>
+  </h1>
+
+  <h2 class="ProfileHeaderCard-screenname u-inlineBlock u-dir" dir="ltr">
+    <a class="ProfileHeaderCard-screennameLink u-linkComplex js-nav" href="/github">@<span class="u-linkComplex-target">github</span></a>
+  </h2>
+
+    <p class="ProfileHeaderCard-bio u-dir"
+      
+      dir="ltr">How people build software</p>
+
+      <div class="ProfileHeaderCard-location">
+        <span class="Icon Icon--geo Icon--medium"></span>
+        <span class="ProfileHeaderCard-locationText u-dir" dir="ltr">
+            San Francisco, CA
+        </span>
+      </div>
+
+      <div class="ProfileHeaderCard-url ">
+        <span class="Icon Icon--url Icon--medium"></span>
+        <span class="ProfileHeaderCard-urlText u-dir" dir="ltr">  <a class="u-textUserColor" target="_blank" rel="me nofollow" href="https://t.co/FoKGHcCyJJ" title="https://github.com">
+    github.com
+  </a>
+
+</span>
+      </div>
+
+
+      <div class="ProfileHeaderCard-joinDate">
+        <span class="Icon Icon--calendar Icon--small"></span>
+        <span class="ProfileHeaderCard-joinDateText js-tooltip u-dir" dir="ltr" title="8:41 PM - 10 Feb 2008">Joined February 2008</span>
+      </div>
+
+    <div class="ProfileHeaderCard-birthdate u-hidden">
+      <span class="Icon Icon--balloon Icon--medium"></span>
+      <span class="ProfileHeaderCard-birthdateText u-dir" dir="ltr">
+</span>
+    </div>
+
+</div>
+
+
+
+
+
+
+
+      <div class="PhotoRail">
+  <div class="PhotoRail-heading">
+    <span class="Icon Icon--camera Icon--medium u-alignBottom"></span>
+    <span class="PhotoRail-headingText">
+            <a href="/github/media" class="PhotoRail-headingWithCount js-nav">
+                
+                46 Photos and videos
+            </a>
+          <a href="/github/media" class="PhotoRail-headingWithoutCount js-nav">
+            Photos and videos
+          </a>
+    </span>
+  </div>
+  <div class="PhotoRail-mediaBox">
+    <span class="js-photoRailInsertPoint"></span>
+  </div>
+</div>
+
+
+
+</div>
+
+              </div>
+            </div>
+          </div>
+
+          <div class="Grid-cell u-size2of3 u-lg-size3of4">
+            <div class="Grid Grid--withGutter">
+                <div class="Grid-cell">
+                  <div class="js-profileClusterFollow"></div>
+                </div>
+
+              <div class="Grid-cell
+                    u-lg-size2of3
+              " data-test-selector="ProfileTimeline">
+                  
+                    <div class="ProfileHeading">
+  <div class="ProfileHeading-spacer"></div>
+    <div class="ProfileHeading-content">
+      <h2 id="content-main-heading" class="ProfileHeading-title u-hiddenVisually ">Tweets</h2>
+        <ul class="ProfileHeading-toggle">
+            <li class="ProfileHeading-toggleItem
+              
+              is-active
+              "
+              data-element-term="tweets_toggle">
+                Tweets
+            </li>
+            <li class="ProfileHeading-toggleItem
+              
+              
+              u-textUserColor"
+              data-element-term="tweets_with_replies_toggle">
+                <a class="ProfileHeading-toggleLink js-nav" href="/github/with_replies" data-nav="tweets_with_replies_toggle">
+                  Tweets &amp; replies
+                </a>
+            </li>
+            <li class="ProfileHeading-toggleItem
+              
+              
+              u-textUserColor"
+              data-element-term="photos_and_videos_toggle">
+                <a class="ProfileHeading-toggleLink js-nav" href="/github/media" data-nav="photos_and_videos_toggle">
+                  Media
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+
+                  <div class="BlockedWarningTimeline">
+  <h2 class="BlockedWarningTimeline-heading" id="content-main-heading">@github is blocked</h2>
+  <p class="BlockedWarningTimeline-explanation">Are you sure you want to view these Tweets? Viewing Tweets won't unblock @github.</p>
+
+  <button class="btn BlockedWarningTimeline-button">View Tweets</button>
+</div>
+                  
+
+
+
+
+  <div id="scroll-bump-dialog" class="ScrollBumpDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content clearfix">
+
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">
+            
+            GitHub followed
+        </h3>
+      </div>
+
+      <div class="modal-body">
+        <div class="loading">
+          <span class="spinner-bigger"></span>
+        </div>
+        <ol class="ScrollBumpDialog-usersList clearfix js-users-list"></ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+
+    <div id="timeline" class="ProfileTimeline ">
+        <div class="stream-container  "
+    data-max-position="730419214251642880" data-min-position="714522458494140416"
+    >
+
+      <div class="stream-item js-new-items-bar-container">
+</div>
+
+    <div class="stream">
+        <ol class="stream-items js-navigable-stream" id="stream-items-id">
+          
+      <li class="js-stream-item stream-item stream-item expanding-stream-item js-pinned
+" data-item-id="730292560074153985" id="stream-item-tweet-730292560074153985" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward user-pinned
+"
+      
+data-tweet-id="730292560074153985"
+data-item-id="730292560074153985"
+data-permalink-path="/github/status/730292560074153985"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:04 AM - 11 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730292560074153985&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+          <div class="tweet-context with-icn
+    
+     pinned">
+
+      <span class="Icon Icon--small Icon--pinned u-textUserColor"></span>
+
+
+
+
+
+
+
+      
+
+        <span class="js-pinned-text" data-aria-label-part>Pinned Tweet</span>
+
+
+    </div>
+
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730292560074153985" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:04 AM - 11 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462950289" data-time-ms="1462950289000" data-long-form="true">May 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Unlimited private repositories. Unlimited possibilities:<a href="https://t.co/nxtv667Qk6" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2164-introducing-unlimited-private-repositories?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=ww-unlimited-private-repos-20160511" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2164-introducing-unlimited-private-repositories?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=ww-unlimited-private-repos-20160511" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2164-intr</span><span class="invisible">oducing-unlimited-private-repositories?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=ww-unlimited-private-repos-20160511</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730292560074153985?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/nxtv667Qk6"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730292560074153985?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:04 AM - 11 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730292560074153985"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="2176">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>2,176 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="2020">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>2,020 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2.2K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2.2K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730419214251642880" id="stream-item-tweet-730419214251642880" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730419214251642880"
+data-item-id="730419214251642880"
+data-permalink-path="/github/status/730419214251642880"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="nmsanchez"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;8:28 AM - 11 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730419214251642880&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730419214251642880" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:28 AM - 11 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462980485" data-time-ms="1462980485000" data-long-form="true">May 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Tune into <a href="/nmsanchez" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="15813127" ><s>@</s><b>nmsanchez</b></a>&#39;s closing keynote at <a href="/hashtag/satelliteAMS?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>satelliteAMS</b></a>:<a href="https://t.co/BmE2t7UdI5" rel="nofollow" dir="ltr" data-expanded-url="http://githubuniverse.com/satellite/" class="twitter-timeline-link u-hidden" target="_blank" title="http://githubuniverse.com/satellite/" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">githubuniverse.com/satellite/</span><span class="invisible"></span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730419214251642880?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/BmE2t7UdI5"
+  data-publisher-id=""
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730419214251642880?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:28 AM - 11 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730419214251642880"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="12">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>12 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="16">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>16 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">12</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">12</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">16</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">16</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730412664208265216" id="stream-item-tweet-730412664208265216" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730412664208265216"
+data-item-id="730412664208265216"
+data-permalink-path="/github/status/730412664208265216"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="player"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;8:02 AM - 11 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730412664208265216&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730412664208265216" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:02 AM - 11 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462978924" data-time-ms="1462978924000" data-long-form="true">May 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Building cross-platform desktop apps has never been easier. Learn how with Electron:<a href="https://t.co/5iojwiY6X8" rel="nofollow" dir="ltr" data-expanded-url="https://www.youtube.com/watch?v=8YP_nOCO-4Q" class="twitter-timeline-link u-hidden" target="_blank" title="https://www.youtube.com/watch?v=8YP_nOCO-4Q" ><span class="tco-ellipsis"></span><span class="invisible">https://www.</span><span class="js-display-url">youtube.com/watch?v=8YP_nO</span><span class="invisible">CO-4Q</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="player"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-player"
+  data-src="/i/cards/tfw/v1/730412664208265216?cardname=player&amp;earned=true&amp;lang=en"
+  data-card-name="player"
+  data-card-url="https://t.co/5iojwiY6X8"
+  data-publisher-id="10228272"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730412664208265216?cardname=player&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:02 AM - 11 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730412664208265216"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="104">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>104 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="204">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>204 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">104</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">104</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">204</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">204</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730298546189160448" id="stream-item-tweet-730298546189160448" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730298546189160448"
+data-item-id="730298546189160448"
+data-permalink-path="/github/status/730298546189160448"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="defunkt"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:28 AM - 11 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730298546189160448&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730298546189160448" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:28 AM - 11 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462951716" data-time-ms="1462951716000" data-long-form="true">May 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Check out the stream of all <a href="/hashtag/SatelliteAMS?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>SatelliteAMS</b></a> talks! <a href="/defunkt" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="713263" ><s>@</s><b>defunkt</b></a>&#39;s opening session begins momentarily:<a href="https://t.co/BmE2t7UdI5" rel="nofollow" dir="ltr" data-expanded-url="http://githubuniverse.com/satellite/" class="twitter-timeline-link u-hidden" target="_blank" title="http://githubuniverse.com/satellite/" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">githubuniverse.com/satellite/</span><span class="invisible"></span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730298546189160448?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/BmE2t7UdI5"
+  data-publisher-id=""
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730298546189160448?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:28 AM - 11 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730298546189160448"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="48">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>48 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="44">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>44 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730290559038840832" id="stream-item-tweet-730290559038840832" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730290559038840832"
+data-item-id="730290559038840832"
+data-permalink-path="/github/status/730290559038840832"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:56 PM - 10 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730290559038840832&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730290559038840832" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:56 PM - 10 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462949812" data-time-ms="1462949812000" data-long-form="true">May 10</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Meet Electron 1.0, the best way to build desktop apps with JavaScript, HTML, and CSS... available today:<a href="https://t.co/UKXg1wpVQT" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2167-electron-1-0-is-here" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2167-electron-1-0-is-here" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2167-elec</span><span class="invisible">tron-1-0-is-here</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730290559038840832?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/UKXg1wpVQT"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730290559038840832?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:56 PM - 10 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730290559038840832"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="577">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>577 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="756">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>756 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">756</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">756</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730115766163509248" id="stream-item-tweet-730115766163509248" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730115766163509248"
+data-item-id="730115766163509248"
+data-permalink-path="/github/status/730115766163509248"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:22 PM - 10 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730115766163509248&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730115766163509248" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:22 PM - 10 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462908138" data-time-ms="1462908138000" data-long-form="true">May 10</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Better discoverability for GitHub Pages sites<a href="https://t.co/R52dOcSpte" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2162-better-discoverability-for-github-pages-sites" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2162-better-discoverability-for-github-pages-sites" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2162-bett</span><span class="invisible">er-discoverability-for-github-pages-sites</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/730115766163509248?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/R52dOcSpte"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730115766163509248?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:22 PM - 10 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730115766163509248"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="75">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>75 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="122">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>122 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">75</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">75</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">122</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">122</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730101446423633921" id="stream-item-tweet-730101446423633921" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730101446423633921"
+data-item-id="730101446423633921"
+data-permalink-path="/github/status/730101446423633921"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:25 AM - 10 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730101446423633921&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730101446423633921" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:25 AM - 10 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462904724" data-time-ms="1462904724000" data-long-form="true">May 10</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Introducing a darker side to GitHub Desktop—a new, dark theme is now available on Windows:<a href="https://t.co/YE2Glujl7a" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2169-github-desktop-now-has-a-dark-side" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2169-github-desktop-now-has-a-dark-side" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2169-gith</span><span class="invisible">ub-desktop-now-has-a-dark-side</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730101446423633921?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/YE2Glujl7a"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730101446423633921?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:25 AM - 10 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730101446423633921"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="180">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>180 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="359">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>359 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">359</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">359</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="729788404561489924" id="stream-item-tweet-729788404561489924" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="729788404561489924"
+data-item-id="729788404561489924"
+data-permalink-path="/github/status/729788404561489924"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;2:41 PM - 9 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/729788404561489924&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/729788404561489924" class="tweet-timestamp js-permalink js-nav js-tooltip" title="2:41 PM - 9 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462830089" data-time-ms="1462830089000" data-long-form="true">May 9</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Please join us for a Patchwork in Chicago on May 24:<a href="https://t.co/jKcckqIfUw" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2168-patchwork-chicago" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2168-patchwork-chicago" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2168-patc</span><span class="invisible">hwork-chicago</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/729788404561489924?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/jKcckqIfUw"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/729788404561489924?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>2:41 PM - 9 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/729788404561489924"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="20">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>20 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="729589015435948032" id="stream-item-tweet-729589015435948032" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="729589015435948032"
+data-item-id="729589015435948032"
+data-permalink-path="/github/status/729589015435948032"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;1:29 AM - 9 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/729589015435948032&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/729589015435948032" class="tweet-timestamp js-permalink js-nav js-tooltip" title="1:29 AM - 9 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462782551" data-time-ms="1462782551000" data-long-form="true">May 9</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Amsterdam and Paris friends, please join us for meetups on 10 and 12 May:<a href="https://t.co/NkYVM1mSPx" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2166-atom-and-electron-meetups-in-amsterdam-and-paris" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2166-atom-and-electron-meetups-in-amsterdam-and-paris" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2166-atom</span><span class="invisible">-and-electron-meetups-in-amsterdam-and-paris</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/729589015435948032?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/NkYVM1mSPx"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/729589015435948032?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>1:29 AM - 9 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/729589015435948032"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="70">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>70 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">70</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">70</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="728107437891293187" id="stream-item-tweet-728107437891293187" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="728107437891293187"
+data-item-id="728107437891293187"
+data-permalink-path="/github/status/728107437891293187"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:21 PM - 4 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/728107437891293187&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/728107437891293187" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:21 PM - 4 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462429315" data-time-ms="1462429315000" data-long-form="true">May 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Satellite is next week and we&#39;re almost sold out. Grab a ticket while you can and join us in Amsterdam: <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="43">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>43 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="52">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>52 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">52</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">52</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="727556156273512449" id="stream-item-tweet-727556156273512449" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="727556156273512449"
+data-item-id="727556156273512449"
+data-permalink-path="/github/status/727556156273512449"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/727556156273512449" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:51 AM - 3 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462297879" data-time-ms="1462297879000" data-long-form="true">May 3</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">You can now import repositories with large files from other version control systems: <a href="https://t.co/cyXGXgPNZz" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2163-import-repositories-with-large-files?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=2163-import-repositories-with-large-files" class="twitter-timeline-link" target="_blank" title="https://github.com/blog/2163-import-repositories-with-large-files?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=2163-import-repositories-with-large-files" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2163-impo</span><span class="invisible">rt-repositories-with-large-files?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=2163-import-repositories-with-large-files</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a><a href="https://t.co/mct8X8eBdN" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/mct8X8eBdN</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      allow-expansion
+      
+      is-square
+      is-generic-video
+      
+      has-autoplayable-media"
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-video">
+  <div class="AdaptiveMedia-videoContainer">
+      <div class="PlayableMedia PlayableMedia--gif">
+
+  <div
+    class="PlayableMedia-player
+      
+      
+      "
+    data-playable-media-url=""
+    style="padding-bottom: 38.666666666666664%; background-image:url('https://pbs.twimg.com/tweet_video_thumb/ChjMX6QU4AAJ7Ze.jpg')">
+  </div>
+
+  
+  
+</div>
+
+  </div>
+</div>
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:51 AM - 3 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/727556156273512449"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="181">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>181 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="215">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>215 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">181</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">181</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="727281796044455937" id="stream-item-tweet-727281796044455937" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="727281796044455937"
+data-item-id="727281796044455937"
+data-permalink-path="/github/status/727281796044455937"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="IBM vangoghmuseum"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;4:41 PM - 2 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/727281796044455937&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/727281796044455937" class="tweet-timestamp js-permalink js-nav js-tooltip" title="4:41 PM - 2 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462232467" data-time-ms="1462232467000" data-long-form="true">May 2</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Github Satellite sponsor <a href="/IBM" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="18994444" ><s>@</s><b>IBM</b></a> has a new blog detailing the event and after party <a href="/vangoghmuseum" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="24691376" ><s>@</s><b>vangoghmuseum</b></a>. Details here:<a href="https://t.co/rr8DFT52bC" rel="nofollow" dir="ltr" data-expanded-url="https://developer.ibm.com/dwblog/ibm-is-sponsoring-the-github-satellite-conference/" class="twitter-timeline-link u-hidden" target="_blank" title="https://developer.ibm.com/dwblog/ibm-is-sponsoring-the-github-satellite-conference/" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">developer.ibm.com/dwblog/ibm-is-</span><span class="invisible">sponsoring-the-github-satellite-conference/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/727281796044455937?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/rr8DFT52bC"
+  data-publisher-id="16362921"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/727281796044455937?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>4:41 PM - 2 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/727281796044455937"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="33">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>33 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="57">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>57 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">57</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">57</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="726065354263252992" id="stream-item-tweet-726065354263252992" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="726065354263252992"
+data-item-id="726065354263252992"
+data-permalink-path="/github/status/726065354263252992"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;8:07 AM - 29 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/726065354263252992&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/726065354263252992" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:07 AM - 29 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461942444" data-time-ms="1461942444000" data-long-form="true">Apr 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Get insights from GitHub customers, community, and leaders at Satellite<a href="https://t.co/f0eeNYr2h4" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2161-get-insights-from-github-customers-community-and-leaders-at-satellite" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2161-get-insights-from-github-customers-community-and-leaders-at-satellite" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2161-get-</span><span class="invisible">insights-from-github-customers-community-and-leaders-at-satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/726065354263252992?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/f0eeNYr2h4"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/726065354263252992?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:07 AM - 29 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/726065354263252992"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="21">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>21 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="31">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>31 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">21</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">21</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="725575239187329024" id="stream-item-tweet-725575239187329024" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="725575239187329024"
+data-item-id="725575239187329024"
+data-permalink-path="/github/status/725575239187329024"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="githubuniverse"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:39 PM - 27 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/725575239187329024&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/725575239187329024" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:39 PM - 27 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461825592" data-time-ms="1461825592000" data-long-form="true">Apr 27</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Only two weeks left until GitHub Satellite, the first international conference in the <a href="/githubuniverse" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="2980633674" ><s>@</s><b>githubuniverse</b></a> event series: <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="32">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>32 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="67">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>67 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="725015353034723329" id="stream-item-tweet-725015353034723329" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="725015353034723329"
+data-item-id="725015353034723329"
+data-permalink-path="/github/status/725015353034723329"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;10:35 AM - 26 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/725015353034723329&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/725015353034723329" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:35 AM - 26 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461692104" data-time-ms="1461692104000" data-long-form="true">Apr 26</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Enterprise 2.6 is here with templates and pre-receive hooks to help your team work smarter. See what&#39;s new:<a href="https://t.co/R3zThLcT0H" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2157-github-enterprise-2-6-is-here-with-faster-more-approachable-workflows?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=enterprise-2.6-release" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2157-github-enterprise-2-6-is-here-with-faster-more-approachable-workflows?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=enterprise-2.6-release" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2157-gith</span><span class="invisible">ub-enterprise-2-6-is-here-with-faster-more-approachable-workflows?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=enterprise-2.6-release</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/725015353034723329?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/R3zThLcT0H"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/725015353034723329?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:35 AM - 26 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/725015353034723329"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="115">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>115 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="141">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>141 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">115</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">115</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">141</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">141</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="724978829815648256" id="stream-item-tweet-724978829815648256" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="724978829815648256"
+data-item-id="724978829815648256"
+data-permalink-path="/github/status/724978829815648256"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;8:09 AM - 26 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/724978829815648256&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/724978829815648256" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:09 AM - 26 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461683397" data-time-ms="1461683397000" data-long-form="true">Apr 26</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Technical writers, join us for a special Patchwork in Atlanta on May 6:<a href="https://t.co/LAKRnaNuii" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2160-patchwork-atlanta-for-content-creators" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2160-patchwork-atlanta-for-content-creators" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2160-patc</span><span class="invisible">hwork-atlanta-for-content-creators</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/724978829815648256?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/LAKRnaNuii"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/724978829815648256?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:09 AM - 26 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/724978829815648256"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="31">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>31 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="724737783382691840" id="stream-item-tweet-724737783382691840" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="724737783382691840"
+data-item-id="724737783382691840"
+data-permalink-path="/github/status/724737783382691840"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;4:12 PM - 25 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/724737783382691840&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/724737783382691840" class="tweet-timestamp js-permalink js-nav js-tooltip" title="4:12 PM - 25 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461625927" data-time-ms="1461625927000" data-long-form="true">Apr 25</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Registration is open! Play, sponsor, or donate to our Dodgeball Tournament and support San Francisco nonprofits:<a href="https://t.co/AvGKYsKzKt" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2159-2016-dodgeball-tournament-play-sponsor-donate" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2159-2016-dodgeball-tournament-play-sponsor-donate" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2159-2016</span><span class="invisible">-dodgeball-tournament-play-sponsor-donate</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/724737783382691840?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/AvGKYsKzKt"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/724737783382691840?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>4:12 PM - 25 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/724737783382691840"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="67">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>67 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723557661820751872" id="stream-item-tweet-723557661820751872" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="723557661820751872"
+data-item-id="723557661820751872"
+data-permalink-path="/github/status/723557661820751872"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;10:02 AM - 22 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723557661820751872&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723557661820751872" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:02 AM - 22 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461344564" data-time-ms="1461344564000" data-long-form="true">Apr 22</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">You can now subscribe to additional webhook events<a href="https://t.co/yxbY3BIsfk" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2156-expanded-webhook-events" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2156-expanded-webhook-events" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2156-expa</span><span class="invisible">nded-webhook-events</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/723557661820751872?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/yxbY3BIsfk"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/723557661820751872?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:02 AM - 22 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/723557661820751872"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="66">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>66 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="105">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>105 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">66</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">66</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">105</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">105</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723413639558885376" id="stream-item-tweet-723413639558885376" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="723413639558885376"
+data-item-id="723413639558885376"
+data-permalink-path="/github/status/723413639558885376"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:30 AM - 22 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723413639558885376&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723413639558885376" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:30 AM - 22 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461310226" data-time-ms="1461310226000" data-long-form="true">Apr 22</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Satellite is 2 weeks away! Get your ticket and hear from engineers at Heroku, Facebook, Spotify and more: <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="22">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>22 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="34">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>34 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">22</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">22</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723217327274242049" id="stream-item-tweet-723217327274242049" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="723217327274242049"
+data-item-id="723217327274242049"
+data-permalink-path="/github/status/723217327274242049"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:30 AM - 21 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723217327274242049&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723217327274242049" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:30 AM - 21 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461263422" data-time-ms="1461263422000" data-long-form="true">Apr 21</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Preview GitHub Pages metadata locally<a href="https://t.co/636j3yIPSX" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2154-preview-github-pages-metadata-locally" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2154-preview-github-pages-metadata-locally" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2154-prev</span><span class="invisible">iew-github-pages-metadata-locally</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/723217327274242049?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/636j3yIPSX"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/723217327274242049?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:30 AM - 21 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/723217327274242049"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="44">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>44 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="69">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>69 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">69</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">69</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723058774936711172" id="stream-item-tweet-723058774936711172" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="723058774936711172"
+data-item-id="723058774936711172"
+data-permalink-path="/github/status/723058774936711172"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="KPN Zalando Tesco UBS"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;1:00 AM - 21 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723058774936711172&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723058774936711172" class="tweet-timestamp js-permalink js-nav js-tooltip" title="1:00 AM - 21 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461225620" data-time-ms="1461225620000" data-long-form="true">Apr 21</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">At Satellite, hear how companies like <a href="/KPN" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="19103718" ><s>@</s><b>KPN</b></a>, <a href="/Zalando" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="59900894" ><s>@</s><b>Zalando</b></a>, <a href="/Tesco" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="271986064" ><s>@</s><b>Tesco</b></a>, and <a href="/UBS" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="38237581" ><s>@</s><b>UBS</b></a> are using software to change how they work:<a href="https://t.co/HCdOteglYo" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2155-join-us-at-github-satellite-to-hear-how-top-european-companies-build-software" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2155-join-us-at-github-satellite-to-hear-how-top-european-companies-build-software" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2155-join</span><span class="invisible">-us-at-github-satellite-to-hear-how-top-european-companies-build-software</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/723058774936711172?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/HCdOteglYo"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/723058774936711172?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>1:00 AM - 21 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/723058774936711172"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="33">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>33 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="722466967161028610" id="stream-item-tweet-722466967161028610" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="722466967161028610"
+data-item-id="722466967161028610"
+data-permalink-path="/github/status/722466967161028610"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:48 AM - 19 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/722466967161028610&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/722466967161028610" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:48 AM - 19 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461084522" data-time-ms="1461084522000" data-long-form="true">Apr 19</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Our next Patchwork will be in St. Louis on April 26:<a href="https://t.co/ZQIsiYMPiC" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2153-patchwork-st-louis" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2153-patchwork-st-louis" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2153-patc</span><span class="invisible">hwork-st-louis</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/722466967161028610?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/ZQIsiYMPiC"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/722466967161028610?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:48 AM - 19 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/722466967161028610"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="20">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>20 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="722326422090420224" id="stream-item-tweet-722326422090420224" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="722326422090420224"
+data-item-id="722326422090420224"
+data-permalink-path="/github/status/722326422090420224"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:30 AM - 19 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/722326422090420224&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/722326422090420224" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:30 AM - 19 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461051013" data-time-ms="1461051013000" data-long-form="true">Apr 19</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Satellite is only 3 weeks away! Get your ticket now and join us in Amsterdam:  <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="23">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>23 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="36">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>36 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">23</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">23</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">36</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">36</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="722157438015680512" id="stream-item-tweet-722157438015680512" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="722157438015680512"
+data-item-id="722157438015680512"
+data-permalink-path="/github/status/722157438015680512"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/722157438015680512" class="tweet-timestamp js-permalink js-nav js-tooltip" title="1:18 PM - 18 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461010724" data-time-ms="1461010724000" data-long-form="true">Apr 18</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">The annual GitHub Dodgeball Tournament returns on June 5th. Stay tuned for details!<a href="https://t.co/TRToRi9EQw" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/TRToRi9EQw</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-quadPhoto">
+    <div class="AdaptiveMedia-threeQuartersWidthPhoto">
+      <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXNfVAAI9AyC.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXNfVAAI9AyC.jpg" alt=""
+      style="height: 100%; left: -94px;"
+>
+</div>
+
+
+    </div>
+  <div class="AdaptiveMedia-thirdHeightPhotoContainer">
+      <div class="AdaptiveMedia-thirdHeightPhoto">
+        <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXOMUsAARUet.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXOMUsAARUet.jpg" alt=""
+      style="height: 100%; left: -31px;"
+>
+</div>
+
+
+      </div>      
+      <div class="AdaptiveMedia-thirdHeightPhoto">
+        <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXOMUYAAIkyH.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXOMUYAAIkyH.jpg" alt=""
+      style="height: 100%; left: -31px;"
+>
+</div>
+
+
+      </div>      
+      <div class="AdaptiveMedia-thirdHeightPhoto">
+        <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXNvVAAADso7.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXNvVAAADso7.jpg" alt=""
+      style="height: 100%; left: -31px;"
+>
+</div>
+
+
+      </div>      
+  </div>
+</div>
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>1:18 PM - 18 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/722157438015680512"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="64">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>64 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="209">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>209 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">64</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">64</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">209</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">209</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="720901243703468032" id="stream-item-tweet-720901243703468032" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="720901243703468032"
+data-item-id="720901243703468032"
+data-permalink-path="/github/status/720901243703468032"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;2:07 AM - 15 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/720901243703468032&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/720901243703468032" class="tweet-timestamp js-permalink js-nav js-tooltip" title="2:07 AM - 15 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460711224" data-time-ms="1460711224000" data-long-form="true">Apr 15</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Check out the GitHub Satellite speaker lineup and grab your tickets while they last:<a href="https://t.co/qSJxFTxJt5" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2152-github-satellite-schedule-announced" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2152-github-satellite-schedule-announced" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2152-gith</span><span class="invisible">ub-satellite-schedule-announced</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/720901243703468032?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/qSJxFTxJt5"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/720901243703468032?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>2:07 AM - 15 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/720901243703468032"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="38">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>38 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="43">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>43 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="720664290655469569" id="stream-item-tweet-720664290655469569" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="720664290655469569"
+data-item-id="720664290655469569"
+data-permalink-path="/github/status/720664290655469569"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;10:25 AM - 14 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/720664290655469569&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/720664290655469569" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:25 AM - 14 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460654730" data-time-ms="1460654730000" data-long-form="true">Apr 14</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">CodeConf LA call for proposals deadline extended to April 29. Have something to say about open source? Apply Now:<a href="https://t.co/SIlqKpLumO" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2149-call-for-proposals-codeconf-la-june-27-29-2016" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2149-call-for-proposals-codeconf-la-june-27-29-2016" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2149-call</span><span class="invisible">-for-proposals-codeconf-la-june-27-29-2016</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/720664290655469569?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/SIlqKpLumO"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/720664290655469569?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:25 AM - 14 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/720664290655469569"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="63">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>63 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="80">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>80 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">63</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">63</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="720294383233306625" id="stream-item-tweet-720294383233306625" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="720294383233306625"
+data-item-id="720294383233306625"
+data-permalink-path="/github/status/720294383233306625"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:55 AM - 13 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/720294383233306625&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/720294383233306625" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:55 AM - 13 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460566538" data-time-ms="1460566538000" data-long-form="true">Apr 13</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Quench your thirst with the new GitHub Water Bottle. Now available in the GitHub Shop.<a href="https://t.co/eqze7dLQlX" rel="nofollow" dir="ltr" data-expanded-url="http://shop.github.com/products/water-bottle" class="twitter-timeline-link u-hidden" target="_blank" title="http://shop.github.com/products/water-bottle" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">shop.github.com/products/water</span><span class="invisible">-bottle</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/720294383233306625?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/eqze7dLQlX"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/720294383233306625?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:55 AM - 13 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/720294383233306625"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="136">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>136 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">136</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">136</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="719972773641084928" id="stream-item-tweet-719972773641084928" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="719972773641084928"
+data-item-id="719972773641084928"
+data-permalink-path="/github/status/719972773641084928"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="photonstorm"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:37 PM - 12 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/719972773641084928&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/719972773641084928" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:37 PM - 12 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460489860" data-time-ms="1460489860000" data-long-form="true">Apr 12</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">“Phaser was a weekend creation—utterly unplanned, but utterly wonderful.” Meet <a href="/photonstorm" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="21861033" ><s>@</s><b>photonstorm</b></a> in our new dev profile:<a href="https://t.co/SS3uSQ8wgQ" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2148-meet-richard-davey-creator-of-phaser?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-richard-davey" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2148-meet-richard-davey-creator-of-phaser?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-richard-davey" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2148-meet</span><span class="invisible">-richard-davey-creator-of-phaser?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-richard-davey</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/719972773641084928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/SS3uSQ8wgQ"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/719972773641084928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:37 PM - 12 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/719972773641084928"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="80">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>80 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="184">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>184 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="719528183859703808" id="stream-item-tweet-719528183859703808" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="719528183859703808"
+data-item-id="719528183859703808"
+data-permalink-path="/github/status/719528183859703808"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;7:11 AM - 11 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/719528183859703808&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/719528183859703808" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:11 AM - 11 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460383861" data-time-ms="1460383861000" data-long-form="true">Apr 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Patchwork comes to Reading, UK on April 19. Will you join us?<a href="https://t.co/40C3ytJYDA" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2147-patchwork-reading-uk" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2147-patchwork-reading-uk" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2147-patc</span><span class="invisible">hwork-reading-uk</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/719528183859703808?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/40C3ytJYDA"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/719528183859703808?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>7:11 AM - 11 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/719528183859703808"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="25">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>25 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="25">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>25 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717543492818481156" id="stream-item-tweet-717543492818481156" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="717543492818481156"
+data-item-id="717543492818481156"
+data-permalink-path="/github/status/717543492818481156"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717543492818481156" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:44 PM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459910674" data-time-ms="1459910674000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">That&#39;s a wrap! Thanks everyone for another great <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a>! We&#39;ll see you in 2017.<a href="https://t.co/K1zMWk4ZN1" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/K1zMWk4ZN1</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      is-square
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-singlePhoto">
+    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CfU6ARWW8AAASlA.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CfU6ARWW8AAASlA.jpg" alt=""
+      style="width: 100%; top: -0px;"
+>
+</div>
+
+
+</div>
+
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>7:44 PM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717543492818481156"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="48">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>48 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="201">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>201 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">201</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">201</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717418093547556865" id="stream-item-tweet-717418093547556865" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717418093547556865"
+data-item-id="717418093547556865"
+data-permalink-path="/github/status/717418093547556865"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="fredhutch"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:26 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717418093547556865&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717418093547556865" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:26 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459880777" data-time-ms="1459880777000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">For the team at <a href="/fredhutch" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="16645335" ><s>@</s><b>fredhutch</b></a>, open source is the key to unlocking cancer. Watch the latest OctoTale:<a href="https://t.co/YTTs4lxf4O" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2145-from-the-octotales-video-series-advancing-cancer-research-through-open-source" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2145-from-the-octotales-video-series-advancing-cancer-research-through-open-source" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2145-from</span><span class="invisible">-the-octotales-video-series-advancing-cancer-research-through-open-source</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/717418093547556865?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/YTTs4lxf4O"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717418093547556865?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:26 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717418093547556865"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="47">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>47 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="76">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>76 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">47</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">47</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">76</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">76</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717415340733513728" id="stream-item-tweet-717415340733513728" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717415340733513728"
+data-item-id="717415340733513728"
+data-permalink-path="/github/status/717415340733513728"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:15 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717415340733513728&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717415340733513728" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:15 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459880120" data-time-ms="1459880120000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">You can now verify GPG signed commits and tags!<a href="https://t.co/JM5esTwcOn" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2144-gpg-signature-verification" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2144-gpg-signature-verification" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2144-gpg-</span><span class="invisible">signature-verification</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/717415340733513728?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/JM5esTwcOn"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717415340733513728?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:15 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717415340733513728"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="679">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>679 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="678">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>678 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">679</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">679</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">678</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">678</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717400932531773440" id="stream-item-tweet-717400932531773440" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="717400932531773440"
+data-item-id="717400932531773440"
+data-permalink-path="/github/status/717400932531773440"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="emmajanehw"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717400932531773440" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:18 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459876685" data-time-ms="1459876685000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Kicking off our afternoon <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a> sessions with <a href="/emmajanehw" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="14336120" ><s>@</s><b>emmajanehw</b></a>. Check out the live stream: <a href="https://t.co/nJTSI585zd" rel="nofollow" dir="ltr" data-expanded-url="https://live-stream.github.com/" class="twitter-timeline-link" target="_blank" title="https://live-stream.github.com/" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">live-stream.github.com</span><span class="invisible">/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a><a href="https://t.co/uVrjZgwVpO" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/uVrjZgwVpO</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      is-square
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-singlePhoto">
+    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CfS4WMWXEAEpOQG.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CfS4WMWXEAEpOQG.jpg" alt=""
+      style="width: 100%; top: -0px;"
+>
+</div>
+
+
+</div>
+
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:18 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717400932531773440"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="35">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>35 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="41">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>41 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">35</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">35</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">41</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">41</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717337520900452353" id="stream-item-tweet-717337520900452353" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717337520900452353"
+data-item-id="717337520900452353"
+data-permalink-path="/GitHubEng/status/717337520900452353"
+
+
+
+
+
+
+    data-retweet-id="717395312747237376"
+     data-retweeter="github"
+
+
+  data-screen-name="GitHubEng" data-name="GitHub Engineering" data-user-id="3131295561"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;6:06 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/GitHubEng/status/717337520900452353&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+          <div class="tweet-context with-icn
+    
+    ">
+
+      <span class="Icon Icon--small Icon--retweeted"></span>
+
+
+
+
+
+            <span class="js-retweet-text"><a class="pretty-link js-user-profile-link" href="/github" data-user-id="13334762"><b>GitHub Retweeted</b></a></span>
+
+
+      
+
+
+
+    </div>
+
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/GitHubEng" data-user-id="3131295561">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/593061696039706627/uzIQ4lJF_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub Engineering</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>GitHubEng</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/GitHubEng/status/717337520900452353" class="tweet-timestamp js-permalink js-nav js-tooltip" title="6:06 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459861567" data-time-ms="1459861567000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Introducing DGit by Patrick Reynolds<a href="https://t.co/gqxJJO34jU" rel="nofollow" dir="ltr" data-expanded-url="http://githubengineering.com/introducing-dgit/" class="twitter-timeline-link u-hidden" target="_blank" title="http://githubengineering.com/introducing-dgit/" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">githubengineering.com/introducing-dg</span><span class="invisible">it/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/717337520900452353?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/gqxJJO34jU"
+  data-publisher-id="3131295561"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717337520900452353?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>6:06 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/GitHubEng/status/717337520900452353"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="215">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>215 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="184">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>184 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717375394400362497" id="stream-item-tweet-717375394400362497" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="717375394400362497"
+data-item-id="717375394400362497"
+data-permalink-path="/github/status/717375394400362497"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="p_reynolds"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717375394400362497" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:36 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459870596" data-time-ms="1459870596000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Thanks <a href="/p_reynolds" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="14448514" ><s>@</s><b>p_reynolds</b></a> for talking us through the debut of DGit at <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a>! Get more details: <a href="https://t.co/14zcUwx3zT" rel="nofollow" dir="ltr" data-expanded-url="http://githubengineering.com/introducing-dgit/" class="twitter-timeline-link" target="_blank" title="http://githubengineering.com/introducing-dgit/" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">githubengineering.com/introducing-dg</span><span class="invisible">it/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a><a href="https://t.co/x5pObaZVbu" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/x5pObaZVbu</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      is-square
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-singlePhoto">
+    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CfShHrAUAAAvu2w.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CfShHrAUAAAvu2w.jpg" alt=""
+      style="width: 100%; top: -0px;"
+>
+</div>
+
+
+</div>
+
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:36 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717375394400362497"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="60">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>60 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="96">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>96 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">96</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">96</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717359961781743619" id="stream-item-tweet-717359961781743619" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="717359961781743619"
+data-item-id="717359961781743619"
+data-permalink-path="/github/status/717359961781743619"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="gregkh"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;7:35 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717359961781743619&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717359961781743619" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:35 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459866917" data-time-ms="1459866917000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Kicking off <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a> with a talk from <a href="/gregkh" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="14768955" ><s>@</s><b>gregkh</b></a> of the Linux Foundation. Tune in to the live stream now: <a href="https://t.co/nJTSI585zd" rel="nofollow" dir="ltr" data-expanded-url="https://live-stream.github.com/" class="twitter-timeline-link" target="_blank" title="https://live-stream.github.com/" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">live-stream.github.com</span><span class="invisible">/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="32">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>32 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="32">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>32 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717206379853955073" id="stream-item-tweet-717206379853955073" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="717206379853955073"
+data-item-id="717206379853955073"
+data-permalink-path="/github/status/717206379853955073"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:25 PM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717206379853955073&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717206379853955073" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:25 PM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459830300" data-time-ms="1459830300000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Hear from Heroku, Facebook and more at GitHub Satellite: <a href="https://t.co/AAAKln7Hht" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="38">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>38 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717152191627337729" id="stream-item-tweet-717152191627337729" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717152191627337729"
+data-item-id="717152191627337729"
+data-permalink-path="/github/status/717152191627337729"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;5:49 PM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717152191627337729&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717152191627337729" class="tweet-timestamp js-permalink js-nav js-tooltip" title="5:49 PM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459817381" data-time-ms="1459817381000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Organizations can now block abusive users from public repositories<a href="https://t.co/p59wkq1uhX" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2146-organizations-can-now-block-abusive-users" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2146-organizations-can-now-block-abusive-users" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2146-orga</span><span class="invisible">nizations-can-now-block-abusive-users</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/717152191627337729?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/p59wkq1uhX"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717152191627337729?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>5:49 PM - 4 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717152191627337729"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="376">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>376 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="492">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>492 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">376</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">376</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">492</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">492</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717023229701971968" id="stream-item-tweet-717023229701971968" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717023229701971968"
+data-item-id="717023229701971968"
+data-permalink-path="/github/status/717023229701971968"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:17 AM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717023229701971968&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717023229701971968" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:17 AM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459786634" data-time-ms="1459786634000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">In or around Philadelphia next week? Join us for a Patchwork on April 12:<a href="https://t.co/Z5wu0J8QdI" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2143-patchwork-philadelphia" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2143-patchwork-philadelphia" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2143-patc</span><span class="invisible">hwork-philadelphia</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/717023229701971968?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/Z5wu0J8QdI"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717023229701971968?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:17 AM - 4 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717023229701971968"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="18">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>18 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="30">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>30 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">18</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">18</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">30</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">30</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="716989838390636544" id="stream-item-tweet-716989838390636544" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="716989838390636544"
+data-item-id="716989838390636544"
+data-permalink-path="/GitHubEducation/status/716989838390636544"
+
+
+
+
+
+
+    data-retweet-id="716990281229402116"
+     data-retweeter="github"
+
+
+  data-screen-name="GitHubEducation" data-name="GitHub Education" data-user-id="1943578656"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;7:04 AM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/GitHubEducation/status/716989838390636544&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+          <div class="tweet-context with-icn
+    
+    ">
+
+      <span class="Icon Icon--small Icon--retweeted"></span>
+
+
+
+
+
+            <span class="js-retweet-text"><a class="pretty-link js-user-profile-link" href="/github" data-user-id="13334762"><b>GitHub Retweeted</b></a></span>
+
+
+      
+
+
+
+    </div>
+
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/GitHubEducation" data-user-id="1943578656">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/378800000561692042/a26a14bdfa11b045632e66b05369bc48_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub Education</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>GitHubEducation</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/GitHubEducation/status/716989838390636544" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:04 AM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459778673" data-time-ms="1459778673000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Supporting the student hacker community:<a href="https://t.co/8BARXftyfn" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2140-supporting-the-student-hacker-community" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2140-supporting-the-student-hacker-community" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2140-supp</span><span class="invisible">orting-the-student-hacker-community</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/716989838390636544?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/8BARXftyfn"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/716989838390636544?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>7:04 AM - 4 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/GitHubEducation/status/716989838390636544"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="86">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>86 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="142">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>142 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">86</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">86</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">142</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">142</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715969911462428672" id="stream-item-tweet-715969911462428672" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715969911462428672"
+data-item-id="715969911462428672"
+data-permalink-path="/github/status/715969911462428672"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:31 AM - 1 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715969911462428672&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715969911462428672" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:31 AM - 1 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459535503" data-time-ms="1459535503000" data-long-form="true">Apr 1</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Squash your Pull Requests on merge<a href="https://t.co/dj1eGecO9h" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2141-squash-your-commits" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2141-squash-your-commits" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2141-squa</span><span class="invisible">sh-your-commits</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/715969911462428672?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/dj1eGecO9h"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715969911462428672?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:31 AM - 1 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715969911462428672"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1045">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>1,045 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1035">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>1,035 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715939189964062725" id="stream-item-tweet-715939189964062725" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715939189964062725"
+data-item-id="715939189964062725"
+data-permalink-path="/github/status/715939189964062725"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:29 AM - 1 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715939189964062725&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715939189964062725" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:29 AM - 1 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459528179" data-time-ms="1459528179000" data-long-form="true">Apr 1</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Pages will standardize on a single Markdown engine on May 1st. Here&#39;s why:<a href="https://t.co/pwMdAdEWg5" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2136-a-look-behind-our-decision-to-standardize-on-a-single-markdown-engine-for-github-pages" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2136-a-look-behind-our-decision-to-standardize-on-a-single-markdown-engine-for-github-pages" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2136-a-lo</span><span class="invisible">ok-behind-our-decision-to-standardize-on-a-single-markdown-engine-for-github-pages</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/715939189964062725?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/pwMdAdEWg5"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715939189964062725?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:29 AM - 1 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715939189964062725"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="168">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>168 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="180">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>180 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">168</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">168</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715810869603667970" id="stream-item-tweet-715810869603667970" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715810869603667970"
+data-item-id="715810869603667970"
+data-permalink-path="/github/status/715810869603667970"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:59 AM - 1 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715810869603667970&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715810869603667970" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:59 AM - 1 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459497585" data-time-ms="1459497585000" data-long-form="true">Apr 1</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Check out speakers from Facebook, Heroku and Women Who Code at GitHub Satellite:<a href="https://t.co/tWB9tgUtko" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2142-github-satellite-sessions-preview" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2142-github-satellite-sessions-preview" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2142-gith</span><span class="invisible">ub-satellite-sessions-preview</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/715810869603667970?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/tWB9tgUtko"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715810869603667970?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:59 AM - 1 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715810869603667970"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="60">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>60 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="99">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>99 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">99</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">99</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715287568850366465" id="stream-item-tweet-715287568850366465" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715287568850366465"
+data-item-id="715287568850366465"
+data-permalink-path="/github/status/715287568850366465"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;2:20 PM - 30 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715287568850366465&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715287568850366465" class="tweet-timestamp js-permalink js-nav js-tooltip" title="2:20 PM - 30 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459372820" data-time-ms="1459372820000" data-long-form="true">Mar 30</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">We’re just days away from <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a> on April 5 in NYC. Check out what we have in store:<a href="https://t.co/Wb6mlL8C2f" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2138-git-merge-is-sold-out-see-what-s-on-tap?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-sold-out-20160330" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2138-git-merge-is-sold-out-see-what-s-on-tap?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-sold-out-20160330" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2138-git-</span><span class="invisible">merge-is-sold-out-see-what-s-on-tap?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-sold-out-20160330</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/715287568850366465?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/Wb6mlL8C2f"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715287568850366465?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>2:20 PM - 30 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715287568850366465"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="34">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>34 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="48">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>48 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715217314040438784" id="stream-item-tweet-715217314040438784" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715217314040438784"
+data-item-id="715217314040438784"
+data-permalink-path="/github/status/715217314040438784"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:41 AM - 30 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715217314040438784&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715217314040438784" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:41 AM - 30 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459356070" data-time-ms="1459356070000" data-long-form="true">Mar 30</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Improvements to protected branches: restrict push access and merge out-of-date pull requests<a href="https://t.co/sS3Pa5HIx2" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2137-protected-branches-improvements" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2137-protected-branches-improvements" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2137-prot</span><span class="invisible">ected-branches-improvements</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/715217314040438784?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/sS3Pa5HIx2"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715217314040438784?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:41 AM - 30 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715217314040438784"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="155">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>155 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="170">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>170 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">155</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">155</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">170</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">170</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714947571400060928" id="stream-item-tweet-714947571400060928" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714947571400060928"
+data-item-id="714947571400060928"
+data-permalink-path="/github/status/714947571400060928"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;3:49 PM - 29 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714947571400060928&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714947571400060928" class="tweet-timestamp js-permalink js-nav js-tooltip" title="3:49 PM - 29 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459291758" data-time-ms="1459291758000" data-long-form="true">Mar 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Git Merge is nearly sold out! There are just a handful of tickets left, so get yours while they last:<a href="https://t.co/Kailn2ayML" rel="nofollow" dir="ltr" data-expanded-url="http://git-merge.com?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-nearly-sold-out-20160329" class="twitter-timeline-link u-hidden" target="_blank" title="http://git-merge.com?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-nearly-sold-out-20160329" ><span class="tco-ellipsis"></span><span class="invisible">http://git-merge.com?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-nearly-sold-out-20160329</span><span class="js-display-url">git-merge.com/?utm_source=tw</span><span class="invisible"></span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714947571400060928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/Kailn2ayML"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714947571400060928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>3:49 PM - 29 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714947571400060928"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="33">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>33 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="73">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>73 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">73</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">73</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714890877290700800" id="stream-item-tweet-714890877290700800" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="714890877290700800"
+data-item-id="714890877290700800"
+data-permalink-path="/github/status/714890877290700800"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714890877290700800" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:04 PM - 29 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459278241" data-time-ms="1459278241000" data-long-form="true">Mar 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Saved replies have launched. Now you can save your most commonly used replies. <a href="https://t.co/BHLdUPdE9i" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2135-saved-replies" class="twitter-timeline-link" target="_blank" title="https://github.com/blog/2135-saved-replies" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2135-save</span><span class="invisible">d-replies</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a><a href="https://t.co/e8IYnq5rOP" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/e8IYnq5rOP</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      allow-expansion
+      
+      is-square
+      is-generic-video
+      
+      has-autoplayable-media"
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-video">
+  <div class="AdaptiveMedia-videoContainer">
+      <div class="PlayableMedia PlayableMedia--gif">
+
+  <div
+    class="PlayableMedia-player
+      
+      
+      "
+    data-playable-media-url=""
+    style="padding-bottom: 50.66666666666667%; background-image:url('https://pbs.twimg.com/tweet_video_thumb/CevJOxzW4AAzfUc.jpg')">
+  </div>
+
+  
+  
+</div>
+
+  </div>
+</div>
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:04 PM - 29 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714890877290700800"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="577">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>577 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="695">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>695 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">695</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">695</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714878577611644928" id="stream-item-tweet-714878577611644928" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714878577611644928"
+data-item-id="714878577611644928"
+data-permalink-path="/github/status/714878577611644928"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:15 AM - 29 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714878577611644928&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714878577611644928" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:15 AM - 29 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459275309" data-time-ms="1459275309000" data-long-form="true">Mar 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Meet Sean Marcia, developer, bee saver, and founder of Ruby for Good:<a href="https://t.co/is3LX6jdTx" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2133-meet-sean-marcia-founder-of-ruby-for-good?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-sean-marcia" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2133-meet-sean-marcia-founder-of-ruby-for-good?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-sean-marcia" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2133-meet</span><span class="invisible">-sean-marcia-founder-of-ruby-for-good?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-sean-marcia</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714878577611644928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/is3LX6jdTx"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714878577611644928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:15 AM - 29 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714878577611644928"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="67">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>67 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="111">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>111 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">111</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">111</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714585691863142400" id="stream-item-tweet-714585691863142400" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714585691863142400"
+data-item-id="714585691863142400"
+data-permalink-path="/github/status/714585691863142400"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;3:51 PM - 28 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714585691863142400&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714585691863142400" class="tweet-timestamp js-permalink js-nav js-tooltip" title="3:51 PM - 28 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459205479" data-time-ms="1459205479000" data-long-form="true">Mar 28</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Git 2.8 has been released and we&#39;d like to share some highlights with you:<a href="https://t.co/kAgMCsZjzU" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2131-git-2-8-has-been-released?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=git-release-2.7-20160328" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2131-git-2-8-has-been-released?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=git-release-2.7-20160328" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2131-git-</span><span class="invisible">2-8-has-been-released?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=git-release-2.7-20160328</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714585691863142400?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/kAgMCsZjzU"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714585691863142400?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>3:51 PM - 28 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714585691863142400"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="719">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>719 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="691">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>691 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">719</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">719</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">691</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">691</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714522458494140416" id="stream-item-tweet-714522458494140416" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714522458494140416"
+data-item-id="714522458494140416"
+data-permalink-path="/github/status/714522458494140416"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="AtomEditor"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:40 AM - 28 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714522458494140416&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714522458494140416" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:40 AM - 28 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459190403" data-time-ms="1459190403000" data-long-form="true">Mar 28</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Atom has reached one million active users—all thanks to <a href="/AtomEditor" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="2339397540" ><s>@</s><b>AtomEditor</b></a> supporters and contributors.<a href="https://t.co/CocbtHscmm" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2132-atom-reaches-one-million-active-users" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2132-atom-reaches-one-million-active-users" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2132-atom</span><span class="invisible">-reaches-one-million-active-users</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714522458494140416?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/CocbtHscmm"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714522458494140416?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:40 AM - 28 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714522458494140416"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="314">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>314 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="552">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>552 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">314</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">314</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">552</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">552</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+        </ol>
+        <div class="stream-footer ">
+  <div class='timeline-end has-items has-more-items'>
+    <div class="stream-end">
+  <div class="stream-end-inner">
+      <span class="Icon Icon--large Icon--logo"></span>
+
+    <p class="empty-text">
+        @github hasn&#39;t tweeted yet.
+
+    </p>
+
+          <p><button type='button' class='btn-link back-to-top hidden'>Back to top &uarr;</button></p>
+
+  </div>
+</div>
+
+    <div class="stream-loading">
+  <div class="stream-end-inner">
+    <span class="spinner" title="Loading..."></span>
+  </div>
+</div>
+
+  </div>
+</div>
+<div class="stream-fail-container">
+    <div class="js-stream-whale-end stream-whale-end stream-placeholder centered-placeholder">
+  <div class="stream-end-inner">
+    <h2 class="title">Loading seems to be taking a while.</h2>
+    <p>
+      Twitter may be over capacity or experiencing a momentary hiccup. <a role="button" href="#" class="try-again-after-whale">Try again</a> or visit <a target="_blank" href="http://status.twitter.com">Twitter Status</a> for more information.
+    </p>
+  </div>
+</div>
+</div>
+
+      <ol class="hidden-replies-container"></ol>
+    </div>
+  </div>
+
+    </div>
+
+
+              </div>
+
+
+                  <div class="Grid-cell u-size1of3">
+                    <div class="Grid Grid--withGutter">
+                      <div class="Grid-cell">
+                        <div class="ProfileSidebar ProfileSidebar--withRightAlignment">
+                          <div class="MoveableModule">
+                            
+<div class="SidebarCommonModules">
+
+
+      <div class="SignupCallOut js-signup-call-out
+  
+  
+   SignupCallOut--fastSignup">
+  <div class="SignupCallOut-header">
+    <h3 class="SignupCallOut-title u-textBreak">
+        
+  New to Twitter?
+
+    </h3>
+  </div>
+    <div class="SignupCallOut-subheader">
+      Sign up now to get your own personalized timeline!
+    </div>
+    <div class="signup SignupForm
+    ">
+    <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn primary-btn"
+    data-component="signup_callout"
+    data-element="form"
+    >Sign up</a>
+  </div>
+
+</div>
+
+
+      <div class="RelatedUsers u-hidden">
+  <div class="RelatedUsers-header">
+    <h3 class="RelatedUsers-title">You may also like</h3>
+    &middot;
+    <button class="btn-link js-refresh-related-users" type="button">Refresh</button>
+  </div>
+
+  <div class="RelatedUsers-users">
+  </div>
+</div>
+
+
+
+    <div class="Trends module trends hidden
+            
+            ">
+  <div class="trends-inner">
+    <div class="flex-module trends-container ">
+  <div class="flex-module-header">
+    
+    <h3><span class="trend-location js-trend-location">San Francisco, CA</span></h3>
+  </div>
+  <div class="flex-module-inner">
+    <ul class="trend-items js-trends">
+    </ul>
+  </div>
+</div>
+  </div>
+</div>
+
+
+  <div class="Footer module roaming-module
+            Footer--slim
+            Footer--blankBackground">
+  <div class="flex-module">
+    <div class="flex-module-inner js-items-container">
+      <ul class="u-cf">
+        <li class="Footer-item Footer-copyright copyright">&copy; 2016 Twitter</li>
+        <li class="Footer-item"><a class="Footer-link" href="/about">About</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com">Help</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="/tos">Terms</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="/privacy">Privacy</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514">Cookies</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170451">Ads info</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+</div>
+
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+  <div id="trends_dialog" class="trends-dialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+          <h3 class="modal-title">
+            
+            Choose a trend location
+          </h3>
+      </div>
+
+      <div class="modal-body">
+
+
+        <div class="trends-dialog-error">
+          <p></p>
+        </div>
+
+        <div class="trends-wrapper" id="trends_dialog_content">
+          
+          <div class="loading">
+            <span class="spinner-bigger"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+          </div>
+        </div>
+      
+    </div>
+    <div class="alert-messages hidden" id="message-drawer">
+    <div class="message ">
+  <div class="message-inside">
+    <span class="message-text"></span>
+      <a role="button" class="Icon Icon--close Icon--medium dismiss" href="#">
+        <span class="visuallyhidden">Dismiss</span>
+      </a>
+  </div>
+</div>
+</div>
+
+    
+
+
+<div class="gallery-overlay"></div>
+<div class="Gallery">
+  <div class="Gallery-closeTarget"></div>
+  <div class="Gallery-content">
+    <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+    <div class="Gallery-media"></div>
+    <div class="GalleryNav GalleryNav--prev">
+      <span class="GalleryNav-handle GalleryNav-handle--prev">
+        <span class="Icon Icon--caretLeft Icon--large">
+          <span class="u-hiddenVisually">
+            Previous
+          </span>
+        </span>
+      </span>
+    </div>
+    <div class="GalleryNav GalleryNav--next">
+      <span class="GalleryNav-handle GalleryNav-handle--next">
+        <span class="Icon Icon--caretRight Icon--large">
+          <span class="u-hiddenVisually">
+            Next
+          </span>
+        </span>
+      </span>
+    </div>
+    <div class="GalleryTweet"></div>
+  </div>
+</div>
+
+
+
+<div class="modal-overlay"></div>
+
+<div id="profile-hover-container"></div>
+
+
+
+<div id="goto-user-dialog" class="modal-container">
+  <div class="modal modal-small draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Go to a person's profile</h3>
+      </div>
+
+      <div class="modal-body">
+        <div class="modal-inner">
+          <form class="t1-form goto-user-form">
+            <input class="input-block username-input" type="text" placeholder="Start typing a name to jump to a profile" aria-label="User">
+            
+
+
+<div role="listbox" class="dropdown-menu typeahead">
+  <div aria-hidden="true" class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <div role="presentation" class="dropdown-inner js-typeahead-results">
+    <div role="presentation" class="typeahead-saved-searches">
+  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
+  <ul role="presentation" class="typeahead-items saved-searches-list">
+    
+    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
+      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
+      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+
+    <ul role="presentation" class="typeahead-items typeahead-topics">
+  
+  <li role="presentation" class="typeahead-item typeahead-topic-item">
+    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
+  </li>
+</ul>
+    
+
+
+<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+  
+  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+    
+    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+      <img class="avatar size32" alt="">
+      <span class="typeahead-user-item-info">
+        <span class="fullname"></span>
+        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+        <span class="username"><s>@</s><b></b></span>
+      </span>
+    </a>
+  </li>
+  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
+</ul>
+
+    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
+  
+  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
+</ul>
+    <div role="presentation" class="typeahead-user-select">
+  <div role="presentation" class="typeahead-empty-suggestions">
+    Suggested users
+  </div>
+  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-selected-end"></li>
+  </ul>
+
+  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-accounts-end"></li>
+  </ul>
+</div>
+
+    <div role="presentation" class="typeahead-dm-conversations">
+  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
+    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
+      <a role="option" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+  </div>
+</div>
+
+          </form>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+  <div id="retweet-tweet-dialog" class="RetweetDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="RetweetDialog-modal modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Retweet this to your followers?</h3>
+      </div>
+
+      <form class="t1-form tweet-form condensed RetweetDialog-tweetForm isWithoutComment" data-condensed-text="Add a comment...">
+        <div class="RetweetDialog-commentBox">
+          <span class="visuallyhidden" id="-label">Optional comment for Retweet</span>
+          <div class="tweet-content">
+            <div class="RichEditor">
+  
+  <div class="RichEditor-mozillaCursorWorkaround">&nbsp;</div>
+  <div class="RichEditor-scrollContainer">
+
+
+
+            <div aria-labelledby="-label" id="" class="tweet-box rich-editor"
+              contenteditable="true" spellcheck="true" role="textbox" aria-multiline="true"></div>
+            
+    <div class="RichEditor-pictographs" aria-hidden="true"></div>
+  </div>
+  <div class="RichEditor-mozillaCursorWorkaround">&nbsp;</div>
+</div>
+
+          </div>
+          
+
+
+<div role="listbox" class="dropdown-menu typeahead">
+  <div aria-hidden="true" class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <div role="presentation" class="dropdown-inner js-typeahead-results">
+    <div role="presentation" class="typeahead-saved-searches">
+  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
+  <ul role="presentation" class="typeahead-items saved-searches-list">
+    
+    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
+      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
+      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+
+    <ul role="presentation" class="typeahead-items typeahead-topics">
+  
+  <li role="presentation" class="typeahead-item typeahead-topic-item">
+    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
+  </li>
+</ul>
+    
+
+
+<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+  
+  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+    
+    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+      <img class="avatar size32" alt="">
+      <span class="typeahead-user-item-info">
+        <span class="fullname"></span>
+        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+        <span class="username"><s>@</s><b></b></span>
+      </span>
+    </a>
+  </li>
+  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
+</ul>
+
+    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
+  
+  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
+</ul>
+    <div role="presentation" class="typeahead-user-select">
+  <div role="presentation" class="typeahead-empty-suggestions">
+    Suggested users
+  </div>
+  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-selected-end"></li>
+  </ul>
+
+  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-accounts-end"></li>
+  </ul>
+</div>
+
+    <div role="presentation" class="typeahead-dm-conversations">
+  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
+    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
+      <a role="option" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+  </div>
+</div>
+
+        </div>
+
+        <div class="RetweetDialog-footer u-cf">
+          <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+          <div class="RetweetDialog-tweet modal-body modal-tweet tweet"></div>
+          <div class="tweet-button">
+            <span class="spinner"></span>
+            <span class="RetweetDialog-counter tweet-counter">140</span>
+            <button class="btn primary-btn retweet-action" type="button">
+              <span class="RetweetDialog-retweetActionLabel">
+                <span class="Icon Icon--retweet"></span>
+                Retweet
+              </span>
+              <span class="RetweetDialog-tweetActionLabel">
+                <span class="Icon Icon--tweet"></span>
+                Tweet
+              </span>
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+  <div id="delete-tweet-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Are you sure you want to delete this Tweet?</h3>
+      </div>
+
+      <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+      <div class="modal-body modal-tweet"></div>
+
+      <div class="modal-footer">
+        <button class="btn cancel-action js-close">Cancel</button>
+        <button class="btn primary-btn delete-action">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="quick-promote-dialog" class="QuickPromoteDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Promote this Tweet</h3>
+      </div>
+      <div class="modal-body">
+        <div class="quick-promote-view-container">
+          <div class="media">
+            <iframe
+              class="quick-promote-iframe js-initial-focus"
+              scrolling="no"
+              frameborder="0"
+              src="">
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div id="block-user-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Block</h3>
+      </div>
+
+      <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+      <div class="modal-body modal-tweet"></div>
+
+      <div class="modal-footer">
+        <button class="btn cancel-action js-close">Cancel</button>
+        <button class="btn primary-btn block-action">Block</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+  
+  
+
+     <div id="geo-disabled-dropdown">
+      <div tabindex="-1">
+  <div class="dropdown-caret">
+    <span class="caret-outer"></span>
+    <span class="caret-inner"></span>
+  </div>
+  <ul>
+    <li class="geo-not-enabled-yet">
+      <h2>Add a location to your Tweets</h2>
+      <p>
+        When you tweet with a location, Twitter stores that location.&#32;
+        You can switch location on/off before each Tweet and always have the option to delete your location history.
+        <a href="http://support.twitter.com/forums/26810/entries/78525" target="_blank">Learn more</a>
+      </p>
+      <div>
+        <button type="button" class="geo-turn-on btn primary-btn">Turn location on</button>
+        <button type="button" class="geo-not-now btn-link">Not now</button>
+      </div>
+    </li>
+  </ul>
+</div>
+
+    </div>
+
+  <div id="geo-enabled-dropdown">
+    <div tabindex="-1">
+  <div class="dropdown-caret">
+    <span class="caret-outer"></span>
+    <span class="caret-inner"></span>
+  </div>
+  <div>
+    <div class="geo-query-location">
+      <input class="GeoSearch-queryInput" type="text" autocomplete="off" placeholder="Search for a neighborhood or city">
+      <span class="icon generic-search"></span>
+    </div>
+    <div class="geo-dropdown-status"></div>
+    <ul class="GeoSearch-dropdownMenu"></ul>
+  </div>
+</div>
+
+  </div>
+
+
+  <div id="profile_popup" class="modal-container ProfilePopupContainer--bellbird">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-small draggable">
+    <div class="modal-content clearfix">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Profile summary</h3>
+      </div>
+
+      <div class="modal-body profile-modal">
+
+      </div>
+
+      <div class="loading">
+        <span class="spinner-bigger"></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="list-membership-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-small draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Your lists</h3>
+      </div>
+      <div class="modal-body">
+        <div class="list-membership-content"></div>
+        <span class="spinner lists-spinner" title="Loading&hellip;"></span>
+      </div>
+    </div>
+  </div>
+</div>
+  <div id="list-operations-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Create a new list</h3>
+      </div>
+      <div class="modal-body">
+        
+<div class="list-editor">
+  <div class="field">
+    <label class="t1-label" for="list-name">List name</label>
+    <input id="list-name" type="text" class="text" name="name" value="" />
+  </div>
+  <hr/>
+
+  <div class="field">
+    <label class="t1-label" for="list-description">Description</label>
+    <textarea id="list-description" name="description"></textarea>
+    <span class="help-text">Under 100 characters, optional</span>
+  </div>
+  <hr/>
+
+  <fieldset class="field">
+    <legend class="t1-legend">Privacy</legend>
+    <div class="options">
+      <label class="t1-label" for="list-public-radio">
+        <input class="radio" type="radio" name="mode" id="list-public-radio" value="public" checked="checked"  />
+        <b>Public</b> &middot; Anyone can follow this list
+      </label>
+      <label class="t1-label" for="list-private-radio">
+        <input class="radio" type="radio" name="mode" id="list-private-radio" value="private"  />
+        <b>Private</b> &middot; Only you can access this list
+      </label>
+    </div>
+  </fieldset>
+  <hr/>
+
+  <div class="list-editor-save">
+    <button type="button" class="btn btn-primary update-list-button" data-list-id="">Save list</button>
+  </div>
+
+</div>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="activity-popup-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content clearfix">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title"></h3>
+      </div>
+
+      <div class="modal-body">
+        <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+        <div class="activity-tweet modal-tweet clearfix"></div>
+        <div class="loading">
+          <span class="spinner-bigger"></span>
+        </div>
+        <div class="activity-content clearfix"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+  <div id="copy-link-to-tweet-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Copy link to Tweet</h3>
+      </div>
+      <div class="modal-body">
+        <div class="copy-link-to-tweet-container">
+          <p class="copy-link-to-tweet-instructions">The URL of this tweet is below. Copy it to easily share with friends.</p>
+          <textarea class="link-to-tweet-destination js-initial-focus u-dir" dir="ltr" readonly></textarea>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div id="embed-tweet-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title embed-tweet-title">Embed this Tweet</h3>
+        <h3 class="modal-title embed-video-title">Embed this Video</h3>
+      </div>
+      <div class="modal-body">
+        <div class="embed-code-container">
+  <p class="embed-tweet-instructions">Add this Tweet to your website by copying the code below. <a href="//dev.twitter.com/docs/embedded-tweets">Learn more</a></p>
+  <p class="embed-video-instructions">Add this video to your website by copying the code below. <a href="//dev.twitter.com/docs/embedded-tweets">Learn more</a></p>
+  <form class="t1-form">
+
+    <div class="embed-destination-wrapper">
+      <div class="embed-overlay embed-overlay-spinner"><div class="embed-overlay-content"></div></div>
+      <div class="embed-overlay embed-overlay-error">
+        <p class="embed-overlay-content">Hmm, there was a problem reaching the server. <button type="button" class="btn-link retry-embed">Try again?</button></p>
+      </div>
+      <textarea class="embed-destination js-initial-focus"></textarea>
+      <div class="embed-options">
+        <div class="embed-include-parent-tweet">
+          <label class="t1-label" for="include-parent-tweet">
+            <input type="checkbox" id="include-parent-tweet" class="include-parent-tweet" checked>
+            Include parent Tweet
+          </label>
+        </div>
+        <div class="embed-include-card">
+          <label class="t1-label" for="include-card">
+            <input type="checkbox" id="include-card" class="include-card" checked>
+            Include media
+          </label>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div class="embed-preview">
+    <h3>Preview</h3>
+  </div>
+</div>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+  <div id="login-dialog" class="LoginDialog modal-container u-textCenter">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-large draggable">
+    <div class="LoginDialog-content modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Log in to Twitter</h3>
+      </div>
+      <div class="LoginDialog-body modal-body">
+        <div class="LoginDialog-bird">
+          <span class="Icon Icon--bird Icon--large"></span>
+        </div>
+        <div class="LoginDialog-form">
+<form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
+  data-component="dialog"
+  data-element="login"
+>
+  <div class="LoginForm-input LoginForm-username">
+    <input
+      type="text"
+      class="text-input email-input js-signin-email"
+      name="session[username_or_email]"
+      autocomplete="username"
+      placeholder="Phone, email or username"
+    />
+  </div>
+
+  <div class="LoginForm-input LoginForm-password">
+    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
+  </div>
+
+  <div class="LoginForm-rememberForgot">
+    <label>
+      <input type="checkbox" value="1" name="remember_me" checked="checked">
+      <span>Remember me</span>
+    </label>
+    <span class="separator">&middot;</span>
+    <a class="forgot" href="/account/begin_password_reset">Forgot password?</a>
+  </div>
+
+  <input type="submit" class="submit btn primary-btn js-submit" value="Log in">
+
+    <input type="hidden" name="return_to_ssl" value="true">
+
+  <input type="hidden" name="scribe_log">
+  <input type="hidden" name="redirect_after_login" value="/github">
+  <input type="hidden" value="0ff51e342cbaed52729adbdd37fcab367da1e38f" name="authenticity_token">
+</form>
+        </div>
+      </div>
+      <div class="LoginDialog-footer modal-footer u-textCenter">
+        Don't have an account? <a class="LoginDialog-signupLink" href="https://twitter.com/signup">Sign up &raquo;</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="signup-dialog" class="SignupDialog modal-container u-textCenter">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-large draggable">
+    <div class="SignupDialog-content modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Sign up for Twitter</h3>
+      </div>
+      <div class="SignupDialog-body modal-body">
+        <div class="SignupDialog-icon">
+          <span class="Icon Icon--bird Icon--extraLarge"></span>
+        </div>
+        <h2 class="SignupDialog-heading">Not on Twitter? Sign up, tune into the things you care about, and get updates as they happen.</h2>
+        <div class="SignupDialog-form">
+  <div class="signup SignupForm
+    ">
+    <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn primary-btn"
+    data-component="dialog"
+    data-element="signup"
+    >Sign up</a>
+  </div>
+        </div>
+      </div>
+      <div class="SignupDialog-footer modal-footer u-textCenter">
+        Have an account? <a class="SignupDialog-signinLink" href="/login">Log in &raquo;</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="sms-codes-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Two-way (sending and receiving) short codes:</h3>
+      </div>
+      <div class="modal-body">
+        
+<table id="sms_codes" cellpadding="0" cellspacing="0">
+  <thead>
+    <tr>
+      <th>Country</th>
+      <th>Code</th>
+      <th>For customers of</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>United States</td>
+      <td>40404</td>
+      <td>(any)</td>
+    </tr>
+    <tr>
+      <td>Canada</td>
+      <td>21212</td>
+      <td>(any)</td>
+    </tr>
+    <tr>
+      <td>United Kingdom</td>
+      <td>86444</td>
+      <td>Vodafone, Orange, 3, O2</td>
+    </tr>
+    <tr>
+      <td>Brazil</td>
+      <td>40404</td>
+      <td>Nextel, TIM</td>
+    </tr>
+    <tr>
+      <td>Haiti</td>
+      <td>40404</td>
+      <td>Digicel, Voila</td>
+    </tr>
+    <tr>
+      <td>Ireland</td>
+      <td>51210</td>
+      <td>Vodafone, O2</td>
+    </tr>
+    <tr>
+      <td>India</td>
+      <td>53000</td>
+      <td>Bharti Airtel, Videocon, Reliance</td>
+    </tr>
+    <tr>
+      <td>Indonesia</td>
+      <td>89887</td>
+      <td>AXIS, 3, Telkomsel, Indosat, XL Axiata</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Italy</td>
+      <td>4880804</td>
+      <td>Wind</td>
+    </tr>
+    <tr>
+      <td>3424486444</td>
+      <td>Vodafone</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="3">
+        &raquo; <a class="js-initial-focus" target="_blank" href="http://support.twitter.com/articles/14226-how-to-find-your-twitter-short-code-or-long-code">See SMS short codes for other countries</a>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="leadgen-confirm-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Confirmation</h3>
+      </div>
+      <div class="modal-body">
+        <div class="leadgen-card-container">
+          <div class="media">
+            <iframe
+              class="cards2-promotion-iframe"
+              scrolling="no"
+              frameborder="0"
+              src="">
+            </iframe>
+          </div>
+        </div>
+        <div class="js-macaw-cards-iframe-container" data-card-name="promotion">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div id="auth-webview-dialog" class="AuthWebViewDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">&nbsp;</h3>
+      </div>
+      <div class="modal-body">
+        <div class="auth-webview-view-container">
+          <div class="media">
+            <iframe
+              class="auth-webview-card-iframe js-initial-focus"
+              scrolling="no"
+              frameborder="0"
+              width="590px"
+              height="500px"
+              src="">
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<div id="promptbird-modal-prompt" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal">
+    
+    <button type="button" class="modal-btn js-promptDismiss modal-close js-close">
+      <span class="Icon Icon--close Icon--medium">
+        <span class="visuallyhidden">Close</span>
+      </span>
+    </button>
+    <div class="modal-content"></div>
+  </div>
+</div>
+
+
+   <div id="payment-order-detail-dialog" class="PaymentOrderDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Buy Now</h3>
+      </div>
+      <div class="modal-body">
+        <div class="alert">
+          <h4>Hmm... Something went wrong. Please try again.</h4>
+        </div>
+        <div class="spinner-bigger"></div>
+        <div class="PaymentOrderDialog-orderDetails"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+
+<div id="create-custom-timeline-dialog" class="modal-container"></div>
+<div id="edit-custom-timeline-dialog" class="modal-container"></div>
+<div id="curate-dialog" class="modal-container"></div>
+<div id="media-edit-dialog" class="modal-container"></div>
+
+
+      <div class="PermalinkOverlay PermalinkOverlay-with-background " id="permalink-overlay">
+  <button class="PermalinkOverlay-next PermalinkOverlay-button u-posFixed js-next" type="button">
+    <span class="Icon Icon--caretLeft Icon--large"></span>
+    <span class="u-hiddenVisually">Next Tweet from user</span>
+  </button>
+  <div class="PermalinkOverlay-modal">
+    <div class="PermalinkOverlay-spinnerContainer u-hidden">
+      <div class="PermalinkOverlay-spinner"></div>
+    </div>
+    <div class="PermalinkOverlay-content">
+      <div class="PermalinkOverlay-body"
+>
+      </div>
+    </div>
+  </div>
+</div>
+
+    <div class="hidden" id="hidden-content">
+  <iframe aria-hidden="true" class="tweet-post-iframe" name="tweet-post-iframe"></iframe>
+  <iframe aria-hidden="true" class="dm-post-iframe" name="dm-post-iframe"></iframe>
+
+</div>
+
+    
+    <div id="spoonbill-outer"></div>
+  </body>
+</html>

--- a/tests/test_reponses/twitter2.html
+++ b/tests/test_reponses/twitter2.html
@@ -1,0 +1,15759 @@
+<!DOCTYPE html>
+<!--[if IE 8]><html class="lt-ie10 ie8" lang="en" data-scribe-reduced-action-queue="true"><![endif]-->
+<!--[if IE 9]><html class="lt-ie10 ie9" lang="en" data-scribe-reduced-action-queue="true"><![endif]-->
+<!--[if gt IE 9]><!--><html lang="en" data-scribe-reduced-action-queue="true"><!--<![endif]-->
+  <head>
+    
+    
+    
+    
+    
+    
+    
+    <meta charset="utf-8">
+    
+    <noscript><meta http-equiv="refresh" content="0; URL=https://mobile.twitter.com/i/nojs_router?path=%2Fgithub"></noscript>
+    
+    
+  
+  <script id="bouncer_terminate_iframe" nonce="CjzqTnd3zNoLBeHlK5rejw==">
+    if (window.top != window) {
+  window.top.postMessage({'bouncer': true, 'event': 'complete'}, '*');
+}
+  </script>
+  <script id="swift_action_queue" nonce="CjzqTnd3zNoLBeHlK5rejw==">
+    (function(){function m(a){a||(a=window.event);if(!a)return!1;a.timestamp=(new Date).getTime();!a.target&&a.srcElement&&(a.target=a.srcElement);if(document.documentElement.getAttribute("data-scribe-reduced-action-queue")){var b=a.target;while(b&&b!=document
+.body){if(b.tagName=="A")return;b=b.parentNode}}r("all",s(a));if(!q(a)){r("direct",a);return!0}document.addEventListener||(a=s(a));a.preventDefault=a.stopPropagation=a.stopImmediatePropagation=function(){};if(i){f.push(a);r("captured",a)}else r("ignored",a
+);return!1}function n($){p();for(var a=0,b;b=f[a];a++){var d=$(b.target),e=d.closest("a")[0];if(b.type=="click"&&e){var g=$.data(e,"events"),i=g&&g.click,j=!e.hostname.match(c)||!e.href.match(/#$/);if(!i&&j){window.location=e.href;continue}}d.trigger($.event
+.fix(b))}window.swiftActionQueue.wasFlushed=!0}function o(){for(var a in j){if(a=="all")continue;var b=j[a];for(var c=0;c<b.length;c++)console.log("actionQueue",u(b[c]))}}function p(){clearTimeout(g);for(var a=0,b;b=e[a];a++)document["on"+b]=null}function q
+(a){if(!a.target)return!1;var b=a.target,e=(b.tagName||"").toLowerCase();if(a.metaKey)return!1;if(a.shiftKey&&e=="a")return!1;if(b.hostname&&!b.hostname.match(c))return!1;if(a.type.match(d)&&w(b))return!1;if(e=="label"){var f=b.getAttribute("for");if(f){var g=
+document.getElementById(f);if(g&&v(g))return!1}else for(var i=0,j;j=b.childNodes[i];i++)if(v(j))return!1}return!0}function r(a,b){b.bucket=a;j[a].push(b)}function s(a){var b={};for(var c in a)b[c]=a[c];return b}function t(a){while(a&&a!=document.body){if(a
+.tagName=="A")return a;a=a.parentNode}}function u(b){var c=[];b.bucket&&c.push("["+b.bucket+"]");c.push(b.type);var d=b.target,e=t(d),f="",g,i,j=b.timestamp&&b.timestamp-a;if(b.type==="click"&&e){g=e.className.trim().replace(/\s+/g,".");i=e.id.trim();f=/[^#]$/
+.test(e.href)?" ("+e.href+")":"";d='"'+e.innerText.replace(/\n+/g," ").trim()+'"'}else{g=d.className.trim().replace(/\s+/g,".");i=d.id.trim();d=d.tagName.toLowerCase();b.keyCode&&(d=String.fromCharCode(b.keyCode)+" : "+d)}c.push(d+f+(i&&"#"+i)+(!i&&g?"."+g
+:""));j&&c.push(j);return c.join(" ")}function v(a){var b=(a.tagName||"").toLowerCase();return b=="input"&&a.getAttribute("type")=="checkbox"}function w(a){var b=(a.tagName||"").toLowerCase();return b=="textarea"||b=="input"&&a.getAttribute("type")=="text"||
+a.getAttribute("contenteditable")=="true"}var a=(new Date).getTime(),b=1e4,c=/^([^\.]+\.)*twitter\.com$/,d=/^key/,e=["click","keydown","keypress","keyup"],f=[],g=null,i=!0,j={captured:[],ignored:[],direct:[],all:[]};for(var k=0,l;l=e[k];k++)document["on"+l
+]=m;g=setTimeout(function(){i=!1},b);window.swiftActionQueue={buckets:j,flush:n,logActions:o,wasFlushed:!1}})();
+  </script>
+  <script id="composition_state" nonce="CjzqTnd3zNoLBeHlK5rejw==">
+    (function(){function a(a){a.target.setAttribute("data-in-composition","true")}function b(a){a.target.removeAttribute("data-in-composition")}if(document.addEventListener){document.addEventListener("compositionstart",a,!1);document.addEventListener("compositionend"
+,b,!1)}})();
+  </script>
+
+    <link rel="stylesheet" href="https://abs.twimg.com/a/1463112091/css/t1/twitter_core.bundle.css">
+  <link rel="stylesheet" href="https://abs.twimg.com/a/1463112091/css/t1/twitter_more_1.bundle.css">
+  <link rel="stylesheet" href="https://abs.twimg.com/a/1463112091/css/t1/twitter_more_2.bundle.css">
+
+    <link rel="dns-prefetch" href="https://pbs.twimg.com">
+    <link rel="dns-prefetch" href="https://t.co">
+      <link rel="preload" href="https://abs.twimg.com/c/swift/en/init.1c978d330d095c4fc1fa8dac83a9d2fa3c0ac53e.js" as="script">
+      <link rel="preload" href="https://abs.twimg.com/c/swift/en/bundle/timeline.6e2eac2c4e3ab6467a54813debdfa9061032bcd9.js" as="script">
+      <link rel="preload" href="https://abs.twimg.com/c/swift/en/bundle/boot.15a9fcfd58386ae29cdba949d3a146059b88ced4.js" as="script">
+
+      <title>GitHub (@github) | Twitter</title>
+      <meta name="robots" content="NOODP">
+  <meta name="description" content="The latest Tweets from GitHub (@github). How people build software. San Francisco, CA">
+
+
+
+<meta name="msapplication-TileImage" content="//abs.twimg.com/favicons/win8-tile-144.png"/>
+<meta name="msapplication-TileColor" content="#00aced"/>
+
+
+<link rel="mask-icon" sizes="any" href="https://abs.twimg.com/a/1463112091/img/t1/favicon.svg" color="#55acee">
+
+  <link href="//abs.twimg.com/favicons/favicon.ico" rel="shortcut icon" type="image/x-icon">
+
+<link rel="manifest" href="/manifest.json">
+
+
+  <meta name="swift-page-name" id="swift-page-name" content="profile">
+
+    <link rel="canonical" href="https://twitter.com/github">
+  <link rel="alternate" hreflang="x-default" href="https://twitter.com/github">
+  <link rel="alternate" hreflang="fr" href="https://twitter.com/github?lang=fr"><link rel="alternate" hreflang="en" href="https://twitter.com/github?lang=en"><link rel="alternate" hreflang="ar" href="https://twitter.com/github?lang=ar"><link rel="alternate" hreflang="ja" href="https://twitter.com/github?lang=ja"><link rel="alternate" hreflang="es" href="https://twitter.com/github?lang=es"><link rel="alternate" hreflang="de" href="https://twitter.com/github?lang=de"><link rel="alternate" hreflang="it" href="https://twitter.com/github?lang=it"><link rel="alternate" hreflang="id" href="https://twitter.com/github?lang=id"><link rel="alternate" hreflang="pt" href="https://twitter.com/github?lang=pt"><link rel="alternate" hreflang="ko" href="https://twitter.com/github?lang=ko"><link rel="alternate" hreflang="tr" href="https://twitter.com/github?lang=tr"><link rel="alternate" hreflang="ru" href="https://twitter.com/github?lang=ru"><link rel="alternate" hreflang="nl" href="https://twitter.com/github?lang=nl"><link rel="alternate" hreflang="fil" href="https://twitter.com/github?lang=fil"><link rel="alternate" hreflang="ms" href="https://twitter.com/github?lang=ms"><link rel="alternate" hreflang="zh-tw" href="https://twitter.com/github?lang=zh-tw"><link rel="alternate" hreflang="zh-cn" href="https://twitter.com/github?lang=zh-cn"><link rel="alternate" hreflang="hi" href="https://twitter.com/github?lang=hi"><link rel="alternate" hreflang="no" href="https://twitter.com/github?lang=no"><link rel="alternate" hreflang="sv" href="https://twitter.com/github?lang=sv"><link rel="alternate" hreflang="fi" href="https://twitter.com/github?lang=fi"><link rel="alternate" hreflang="da" href="https://twitter.com/github?lang=da"><link rel="alternate" hreflang="pl" href="https://twitter.com/github?lang=pl"><link rel="alternate" hreflang="hu" href="https://twitter.com/github?lang=hu"><link rel="alternate" hreflang="fa" href="https://twitter.com/github?lang=fa"><link rel="alternate" hreflang="he" href="https://twitter.com/github?lang=he"><link rel="alternate" hreflang="ur" href="https://twitter.com/github?lang=ur"><link rel="alternate" hreflang="th" href="https://twitter.com/github?lang=th"><link rel="alternate" hreflang="uk" href="https://twitter.com/github?lang=uk"><link rel="alternate" hreflang="ca" href="https://twitter.com/github?lang=ca"><link rel="alternate" hreflang="ga" href="https://twitter.com/github?lang=ga"><link rel="alternate" hreflang="el" href="https://twitter.com/github?lang=el"><link rel="alternate" hreflang="eu" href="https://twitter.com/github?lang=eu"><link rel="alternate" hreflang="cs" href="https://twitter.com/github?lang=cs"><link rel="alternate" hreflang="gl" href="https://twitter.com/github?lang=gl"><link rel="alternate" hreflang="ro" href="https://twitter.com/github?lang=ro"><link rel="alternate" hreflang="hr" href="https://twitter.com/github?lang=hr"><link rel="alternate" hreflang="en-gb" href="https://twitter.com/github?lang=en-gb"><link rel="alternate" hreflang="vi" href="https://twitter.com/github?lang=vi"><link rel="alternate" hreflang="bn" href="https://twitter.com/github?lang=bn"><link rel="alternate" hreflang="bg" href="https://twitter.com/github?lang=bg"><link rel="alternate" hreflang="sr" href="https://twitter.com/github?lang=sr"><link rel="alternate" hreflang="sk" href="https://twitter.com/github?lang=sk"><link rel="alternate" hreflang="gu" href="https://twitter.com/github?lang=gu"><link rel="alternate" hreflang="mr" href="https://twitter.com/github?lang=mr"><link rel="alternate" hreflang="ta" href="https://twitter.com/github?lang=ta"><link rel="alternate" hreflang="kn" href="https://twitter.com/github?lang=kn">
+
+
+  <link rel="alternate" media="handheld, only screen and (max-width: 640px)" href="https://mobile.twitter.com/github">
+
+      <link rel="alternate" href="android-app://com.twitter.android/twitter/user?screen_name=github&amp;ref_src=twsrc%5Egoogle%7Ctwcamp%5Eandroidseo%7Ctwgr%5Eprofile">
+
+<link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Twitter">
+
+    <link id="async-css-placeholder">
+
+      <input type="hidden" id="init-data" class="json-data" value="{&quot;permalinkOverlayEnabled&quot;:false,&quot;hasKenburnEffectOnSingleImage&quot;:false,&quot;maxTweetComposeCharacters&quot;:140,&quot;composeIgnoreAttachmentText&quot;:false,&quot;baseFoucClass&quot;:&quot;swift-loading&quot;,&quot;bodyFoucClassNames&quot;:&quot;swift-loading&quot;,&quot;macawSwift&quot;:true,&quot;assetsBasePath&quot;:&quot;https:\/\/abs.twimg.com\/a\/1463112091\/&quot;,&quot;assetVersionKey&quot;:&quot;c88735&quot;,&quot;environment&quot;:&quot;production&quot;,&quot;formAuthenticityToken&quot;:&quot;0ff51e342cbaed52729adbdd37fcab367da1e38f&quot;,&quot;loggedIn&quot;:false,&quot;screenName&quot;:null,&quot;fullName&quot;:null,&quot;userId&quot;:null,&quot;guestId&quot;:&quot;146323067541706309&quot;,&quot;allowAdsPersonalization&quot;:true,&quot;scribeBufferSize&quot;:3,&quot;pageName&quot;:&quot;profile&quot;,&quot;sectionName&quot;:&quot;profile&quot;,&quot;scribeParameters&quot;:{},&quot;recaptchaApiUrl&quot;:&quot;https:\/\/www.google.com\/recaptcha\/api\/js\/recaptcha_ajax.js&quot;,&quot;internalReferer&quot;:null,&quot;geoEnabled&quot;:false,&quot;typeaheadData&quot;:{&quot;accounts&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;limit&quot;:6},&quot;trendLocations&quot;:{&quot;enabled&quot;:true},&quot;dmConversations&quot;:{&quot;enabled&quot;:false},&quot;savedSearches&quot;:{&quot;enabled&quot;:false,&quot;items&quot;:[]},&quot;dmAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyDMable&quot;:true},&quot;mediaTagAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:true,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyShowUsersWithCanMediaTag&quot;:false,&quot;currentUserId&quot;:-1},&quot;selectedUsers&quot;:{&quot;enabled&quot;:false},&quot;prefillUsers&quot;:{&quot;enabled&quot;:false},&quot;topics&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:4},&quot;concierge&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:6},&quot;recentSearches&quot;:{&quot;enabled&quot;:false},&quot;hashtags&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500},&quot;useIndexedDB&quot;:false,&quot;showSearchAccountSocialContext&quot;:false,&quot;showDebugInfo&quot;:false,&quot;useThrottle&quot;:true,&quot;accountsOnTop&quot;:false,&quot;remoteDebounceInterval&quot;:300,&quot;remoteThrottleInterval&quot;:300,&quot;tweetContextEnabled&quot;:false,&quot;fullNameMatchingInCompose&quot;:true,&quot;topicsWithFiltersEnabled&quot;:false},&quot;dm&quot;:{&quot;notifications&quot;:false,&quot;usePushForNotifications&quot;:false,&quot;participant_max&quot;:50,&quot;video_gif_render&quot;:true,&quot;video_gif_upload&quot;:true,&quot;twitter_video_player&quot;:false,&quot;poll_options&quot;:{&quot;foreground_poll_interval&quot;:3000,&quot;burst_poll_interval&quot;:3000,&quot;burst_poll_duration&quot;:300000,&quot;max_poll_interval&quot;:60000}},&quot;whitelistedVideoUser&quot;:false,&quot;autoplayDisabled&quot;:false,&quot;pushStatePageLimit&quot;:500000,&quot;routes&quot;:{&quot;profile&quot;:&quot;\/&quot;},&quot;pushState&quot;:true,&quot;viewContainer&quot;:&quot;#page-container&quot;,&quot;dragAndDropPhotoUpload&quot;:true,&quot;href&quot;:&quot;\/github&quot;,&quot;searchPathWithQuery&quot;:&quot;\/search?q=query&amp;src=typd&quot;,&quot;timelineCardsGallery&quot;:true,&quot;composeAltText&quot;:false,&quot;deciders&quot;:{&quot;bulkUnfollowEnabled&quot;:true,&quot;custom_timeline_curation&quot;:false,&quot;moment_maker_enabled&quot;:false,&quot;disable_profile_popup&quot;:false,&quot;native_notifications&quot;:true,&quot;dm_polling_frequency_in_seconds&quot;:3000,&quot;enable_media_tag_prefetch&quot;:true,&quot;foundMediaTrendingEnabled&quot;:false,&quot;enableMacawNymizerConversionLanding&quot;:false,&quot;hqImageUploads&quot;:false,&quot;largeHeaderImageUpload&quot;:true,&quot;mqImageUploads&quot;:false,&quot;partnerIdSyncEnabled&quot;:true,&quot;sruMediaCategory&quot;:false,&quot;photoSruGifLimitMb&quot;:5,&quot;promoted_video_logging_enabled&quot;:true,&quot;pushState&quot;:true,&quot;scribeReducedActionQueue&quot;:true,&quot;smartInfiniteScroll&quot;:false,&quot;useHtml5Webcam&quot;:true,&quot;web_perftown_stats&quot;:true,&quot;web_perftown_ttft&quot;:true,&quot;web_sru_stats&quot;:false,&quot;web_upload_direct&quot;:true,&quot;web_upload_video&quot;:true,&quot;web_upload_video_advanced&quot;:false,&quot;upload_video_size&quot;:500,&quot;internationalShippingEnabled&quot;:true,&quot;useV2EndpointsEnabled&quot;:true,&quot;useVmapVariants&quot;:false,&quot;autoplayPreviewPreroll&quot;:true,&quot;moments_lohp_enabled&quot;:true,&quot;overlayPermalink&quot;:true,&quot;momentsExperienceEnabled&quot;:false,&quot;enableNativePush&quot;:false,&quot;installNativePush&quot;:false,&quot;autoSubscribeNativePush&quot;:false,&quot;composeLimits&quot;:{&quot;enabled&quot;:false,&quot;hashtags&quot;:50,&quot;mentions&quot;:50,&quot;links&quot;:10},&quot;stickersInteractivity&quot;:false,&quot;stickersInteractivityDuringLoading&quot;:false,&quot;stickersExperience&quot;:false,&quot;dynamic_video_ads_include_long_videos&quot;:true,&quot;push_state_size&quot;:1000},&quot;experiments&quot;:{},&quot;toasts_dm&quot;:false,&quot;toasts_spoonbill&quot;:false,&quot;toasts_timeline&quot;:false,&quot;toasts_dm_poll_scale&quot;:60,&quot;defaultNotificationIcon&quot;:&quot;https:\/\/abs.twimg.com\/a\/1463112091\/img\/t1\/mobile\/wp7_app_icon.png&quot;,&quot;uploadDomain&quot;:&quot;upload.twitter.com&quot;,&quot;promptbirdData&quot;:{&quot;promptbirdEnabled&quot;:false,&quot;immediateTriggers&quot;:[&quot;PullToRefresh&quot;,&quot;Navigate&quot;],&quot;format&quot;:&quot;ProfileOther&quot;},&quot;pageContext&quot;:&quot;profile&quot;,&quot;passwordResetAdvancedLoginForm&quot;:true,&quot;skipAutoSignupDialog&quot;:false,&quot;shouldReplaceSignupWithLogin&quot;:false,&quot;hashflagBaseUrl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/&quot;,&quot;activeHashflags&quot;:{&quot;أف_جيه&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;meinestimme&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;اقترعت&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;abematv&quot;:&quot;CyberAgentJapan\/AbemaTV.png&quot;,&quot;teamblake&quot;:&quot;TheVoice2016\/teamblake.png&quot;,&quot;bts&quot;:&quot;BTS\/BTS.png&quot;,&quot;أوريون&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;periscope&quot;:&quot;Periscope\/Periscope.png&quot;,&quot;thefalcon&quot;:&quot;CaptainAmericaCivilWar2\/TheFalcon.png&quot;,&quot;eurovision&quot;:&quot;eurovision2016\/Eurovision.png&quot;,&quot;timecapitãoamérica&quot;:&quot;DisneyMarvel\/TeamCap.png&quot;,&quot;frappuccinohappyhour&quot;:&quot;Starbucks2\/OriginalFile.png&quot;,&quot;lovetwitter&quot;:&quot;LoveTwitter\/LoveTwitter.png&quot;,&quot;teamironman&quot;:&quot;DisneyMarvel\/TeamIronman.png&quot;,&quot;تويوتا_السعودية&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;stanleycup&quot;:&quot;NHL\/StanleyCup.png&quot;,&quot;تويوتا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;ausvotes&quot;:&quot;AusVotes\/AusVotes.png&quot;,&quot;يارس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;ifoodsalva&quot;:&quot;iFood\/emoji_ifood_v2_final.png&quot;,&quot;كامري&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;방탄소년단&quot;:&quot;BTS\/BTS.png&quot;,&quot;hakkebakke&quot;:&quot;VodafoneFiles\/FinalEmoji.png&quot;,&quot;gameofthrones&quot;:&quot;GameofThrones\/GameofThrones.png&quot;,&quot;الأهلي&quot;:&quot;SaudiProfessionalLeague\/Al-Ahli.png&quot;,&quot;داينا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;hovotato&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;shakespeare400&quot;:&quot;Shakespeare400\/Shakespeare400.png&quot;,&quot;япроголосовал(а)&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;sienteelsabor&quot;:&quot;CocaCola\/SienteElSabor.png&quot;,&quot;راف_فور&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;teampharrell&quot;:&quot;TheVoice2016\/teampharrell.png&quot;,&quot;besuper&quot;:&quot;VodafoneFiles\/FinalEmoji.png&quot;,&quot;warmachine&quot;:&quot;CaptainAmericaCivilWar2\/WarMachine.png&quot;,&quot;hawkeye&quot;:&quot;CaptainAmericaCivilWar2\/Hawkeye.png&quot;,&quot;jaivoté&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;golive&quot;:&quot;goLIVE2016\/goLIVE.png&quot;,&quot;أفالون&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;laliga&quot;:&quot;LaLiga\/LaLiga.png&quot;,&quot;أفانزا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;我已投票&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;برادو&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;تويوتا_عبداللطيف_جميل&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;teamadam&quot;:&quot;TheVoice2016\/teamadam.png&quot;,&quot;thevision&quot;:&quot;CaptainAmericaCivilWar2\/TheVision.png&quot;,&quot;nouvellestar&quot;:&quot;NouvelleStar2016\/NouvelleStar.png&quot;,&quot;فورتشنر&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;fazerdiferente&quot;:&quot;TIM\/emoji_tim_final_3.png&quot;,&quot;كورولا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;هايلكس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;blackpanther&quot;:&quot;CaptainAmericaCivilWar2\/BlackPanther.png&quot;,&quot;estiempode&quot;:&quot;att-emoji2-assets\/attemoji2.png&quot;,&quot;كوستر&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;souflamengosoumaior&quot;:&quot;Flamengo\/Flamengo.png&quot;,&quot;antman&quot;:&quot;CaptainAmericaCivilWar2\/AntMan.png&quot;,&quot;إنوفا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;teamcap&quot;:&quot;DisneyMarvel\/TeamCap.png&quot;,&quot;투표했어요&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;spiderman&quot;:&quot;CaptainAmericaCivilWar2\/spiderman.png&quot;,&quot;rumoaorio&quot;:&quot;100Days\/100Days.png&quot;,&quot;لاندكروزر&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;bucky&quot;:&quot;CaptainAmericaCivilWar2\/WinterSoldierBucky.png&quot;,&quot;shakespearelives&quot;:&quot;Shakespeare400\/Shakespeare400.png&quot;,&quot;teamchristina&quot;:&quot;TheVoice2016\/teamxtina.png&quot;,&quot;تويوتا86&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;chamaolimpica&quot;:&quot;OlympicTorch_Emoji\/OlympicTorch.png&quot;,&quot;ivoted&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;teamxtina&quot;:&quot;TheVoice2016\/teamxtina.png&quot;,&quot;bandoironman&quot;:&quot;DisneyMarvel\/TeamIronman.png&quot;,&quot;الهلال&quot;:&quot;SaudiProfessionalLeague\/Al-Hilal.png&quot;,&quot;nsvote&quot;:&quot;NouvelleStar2016\/NSvote.png&quot;,&quot;olympicflame&quot;:&quot;OlympicTorch_Emoji\/OlympicTorch.png&quot;,&quot;timehomemdeferro&quot;:&quot;DisneyMarvel\/TeamIronman.png&quot;,&quot;desapega&quot;:&quot;olx\/emoji_olx_final.png&quot;,&quot;ograndvoltou&quot;:&quot;McDonalds\/emoji_mc_final.png&quot;,&quot;bandocapi&quot;:&quot;DisneyMarvel\/TeamCap.png&quot;,&quot;uncharted4&quot;:&quot;drake\/Drake.png&quot;,&quot;حزامك_أمانك&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;flamengo&quot;:&quot;Flamengo\/Flamengo.png&quot;,&quot;blackwidow&quot;:&quot;CaptainAmericaCivilWar2\/BlackWidow.png&quot;,&quot;بريوس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;keepdancing&quot;:&quot;KeepDancing\/KeepDancing.png&quot;,&quot;لاندكروزر_70&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;scarletwitch&quot;:&quot;CaptainAmericaCivilWar2\/ScarletWitch.png&quot;,&quot;الاهلي&quot;:&quot;SaudiProfessionalLeague\/Al-Ahli.png&quot;,&quot;thisishappening&quot;:&quot;KeepDancing\/KeepDancing.png&quot;,&quot;هايلوكس&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;بريفيا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;wintersoldier&quot;:&quot;CaptainAmericaCivilWar2\/WinterSoldierBucky.png&quot;,&quot;timão&quot;:&quot;Corinthians\/Corinthians.png&quot;,&quot;لاندكروزر_مصندق&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;rumboario&quot;:&quot;100Days\/100Days.png&quot;,&quot;الاتحاد&quot;:&quot;SaudiProfessionalLeague\/Al-Ittihad.png&quot;,&quot;النصر&quot;:&quot;SaudiProfessionalLeague\/Al-Nassr.png&quot;,&quot;لاندكروزر_بيك_اب&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;yovoté&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;corinthians&quot;:&quot;Corinthians\/Corinthians.png&quot;,&quot;roadtorio&quot;:&quot;100Days\/100Days.png&quot;,&quot;عبداللطيف_جميل&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;icaucused&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;spidey&quot;:&quot;CaptainAmericaCivilWar2\/spiderman.png&quot;,&quot;سيكويا&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;تويوتا_أكيد&quot;:&quot;ToyotaALJ-Final_160421\/thumbsup2.png&quot;,&quot;frappuccino&quot;:&quot;Starbucks\/OriginalFile.png&quot;,&quot;amici15&quot;:&quot;amiciemojifiles\/amici_emoji.png&quot;,&quot;vaicorinthians&quot;:&quot;Corinthians\/Corinthians.png&quot;,&quot;omantoehmeu&quot;:&quot;Flamengo\/Flamengo.png&quot;,&quot;timao&quot;:&quot;Corinthians\/Corinthians.png&quot;},&quot;profile_user&quot;:{&quot;id&quot;:13334762,&quot;id_str&quot;:&quot;13334762&quot;,&quot;name&quot;:&quot;GitHub&quot;,&quot;screen_name&quot;:&quot;github&quot;,&quot;location&quot;:&quot;San Francisco, CA&quot;,&quot;url&quot;:&quot;https:\/\/github.com&quot;,&quot;description&quot;:&quot;How people build software&quot;,&quot;protected&quot;:false,&quot;followers_count&quot;:842686,&quot;friends_count&quot;:192,&quot;listed_count&quot;:12484,&quot;created_at&quot;:&quot;Mon Feb 11 04:41:50 +0000 2008&quot;,&quot;favourites_count&quot;:160,&quot;utc_offset&quot;:-25200,&quot;time_zone&quot;:&quot;Pacific Time (US &amp; Canada)&quot;,&quot;geo_enabled&quot;:true,&quot;verified&quot;:true,&quot;statuses_count&quot;:3230,&quot;lang&quot;:&quot;en&quot;,&quot;contributors_enabled&quot;:false,&quot;is_translator&quot;:false,&quot;is_translation_enabled&quot;:false,&quot;profile_background_color&quot;:&quot;EEEEEE&quot;,&quot;profile_background_image_url&quot;:&quot;http:\/\/pbs.twimg.com\/profile_background_images\/4229589\/header_bg.png&quot;,&quot;profile_background_image_url_https&quot;:&quot;https:\/\/pbs.twimg.com\/profile_background_images\/4229589\/header_bg.png&quot;,&quot;profile_background_tile&quot;:false,&quot;profile_image_url&quot;:&quot;http:\/\/pbs.twimg.com\/profile_images\/616309728688238592\/pBeeJQDQ_normal.png&quot;,&quot;profile_image_url_https&quot;:&quot;https:\/\/pbs.twimg.com\/profile_images\/616309728688238592\/pBeeJQDQ_normal.png&quot;,&quot;profile_banner_url&quot;:&quot;https:\/\/pbs.twimg.com\/profile_banners\/13334762\/1415719104&quot;,&quot;profile_link_color&quot;:&quot;0000FF&quot;,&quot;profile_sidebar_border_color&quot;:&quot;BBBBBB&quot;,&quot;profile_sidebar_fill_color&quot;:&quot;DDDDDD&quot;,&quot;profile_text_color&quot;:&quot;000000&quot;,&quot;profile_use_background_image&quot;:false,&quot;has_extended_profile&quot;:false,&quot;default_profile&quot;:false,&quot;default_profile_image&quot;:false,&quot;following&quot;:null,&quot;follow_request_sent&quot;:null,&quot;notifications&quot;:null,&quot;ext&quot;:{&quot;vine_profile&quot;:{&quot;r&quot;:{&quot;err&quot;:{&quot;code&quot;:202,&quot;message&quot;:&quot;You are not authorized to request this information.&quot;}},&quot;ttl&quot;:0}}},&quot;profileEditingCSSBundle&quot;:&quot;https:\/\/abs.twimg.com\/a\/1463112091\/css\/t1\/twitter_profile_editing.bundle.css&quot;,&quot;profile_id&quot;:13334762,&quot;businessProfile&quot;:false,&quot;cardsGallery&quot;:true,&quot;injectComposedTweets&quot;:false,&quot;help_pips_decider&quot;:false,&quot;inlineProfileEditing&quot;:false,&quot;forceHTML5FileUploader&quot;:false,&quot;isClusterFollowReplenishEnabled&quot;:false,&quot;autoplayEnabled&quot;:true,&quot;trendsCacheKey&quot;:null,&quot;decider_personalized_trends&quot;:false,&quot;trendsEndpoint&quot;:&quot;\/i\/trends&quot;,&quot;wtfOptions&quot;:{&quot;pc&quot;:false,&quot;connections&quot;:true,&quot;limit&quot;:3,&quot;display_location&quot;:&quot;profile-sidebar&quot;,&quot;dismissable&quot;:true,&quot;similar_to_user_id&quot;:13334762},&quot;showSensitiveContent&quot;:false,&quot;autoPlayBalloonsAnimation&quot;:false,&quot;isCurrentUser&quot;:false,&quot;timeline_url&quot;:&quot;\/i\/profiles\/show\/github\/timeline\/tweets&quot;,&quot;initialState&quot;:{&quot;title&quot;:&quot;GitHub (@github) | Twitter&quot;,&quot;section&quot;:null,&quot;module&quot;:&quot;app\/pages\/profile\/highline_landing&quot;,&quot;cache_ttl&quot;:300,&quot;body_class_names&quot;:&quot;three-col logged-out user-style-github enhanced-mini-profile ProfilePage ProfilePage--withBlockedWarning&quot;,&quot;doc_class_names&quot;:&quot;route-profile&quot;,&quot;route_name&quot;:&quot;profile&quot;,&quot;page_container_class_names&quot;:&quot;AppContent&quot;,&quot;ttft_navigation&quot;:false}}">
+
+  
+
+    <input type="hidden" class="swift-boot-module" value="app/pages/profile/highline_landing">
+  <input type="hidden" id="swift-module-path" value="https://abs.twimg.com/c/swift/en">
+
+  
+    <script src="https://abs.twimg.com/c/swift/en/init.1c978d330d095c4fc1fa8dac83a9d2fa3c0ac53e.js" async></script>
+
+  </head>
+  <body class="three-col logged-out user-style-github enhanced-mini-profile ProfilePage ProfilePage--withBlockedWarning" 
+data-fouc-class-names="swift-loading"
+ dir="ltr">
+      <script id="swift_loading_indicator" nonce="CjzqTnd3zNoLBeHlK5rejw==">
+        document.body.className=document.body.className+" "+document.body.getAttribute("data-fouc-class-names");
+      </script>
+    <div id="doc" class="route-profile">
+        <div class="topbar js-topbar">
+
+
+  <div class="global-nav global-nav--newLoggedOut" data-section-term="top_nav">
+    <div class="global-nav-inner">
+      <div class="container">
+
+        
+<ul class="nav js-global-actions" role="navigation" id="global-actions">
+  <li id="global-nav-home" class="home" data-global-action="home">
+    <a class="js-nav js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/" data-component-context="home_nav" data-nav="home">
+      <span class="Icon Icon--bird Icon--large"></span>
+      <span class="text">Home</span>
+    </a>
+  </li>
+    <li id="global-nav-about" class="about" data-global-action="about">
+      <a class="js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/about" target="_blank" data-component-context="about_nav" data-nav="about">
+        <span class="text">About</span>
+      </a>
+    </li>
+</ul>
+<div class="pull-right">
+    <div role="search">
+  <form class="t1-form form-search js-search-form" action="/search" id="global-nav-search">
+    <label class="visuallyhidden" for="search-query">Search query</label>
+    <input class="search-input" type="text" id="search-query" placeholder="Search Twitter" name="q" autocomplete="off" spellcheck="false">
+    <span class="search-icon js-search-action">
+      <button type="submit" class="Icon Icon--search nav-search">
+        <span class="visuallyhidden">Search Twitter</span>
+      </button>
+    </span>
+      
+
+
+<div role="listbox" class="dropdown-menu typeahead">
+  <div aria-hidden="true" class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <div role="presentation" class="dropdown-inner js-typeahead-results">
+    <div role="presentation" class="typeahead-saved-searches">
+  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
+  <ul role="presentation" class="typeahead-items saved-searches-list">
+    
+    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
+      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
+      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+
+    <ul role="presentation" class="typeahead-items typeahead-topics">
+  
+  <li role="presentation" class="typeahead-item typeahead-topic-item">
+    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
+  </li>
+</ul>
+    
+
+
+<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+  
+  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+    
+    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+      <img class="avatar size32" alt="">
+      <span class="typeahead-user-item-info">
+        <span class="fullname"></span>
+        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+        <span class="username"><s>@</s><b></b></span>
+      </span>
+    </a>
+  </li>
+  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
+</ul>
+
+    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
+  
+  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
+</ul>
+    <div role="presentation" class="typeahead-user-select">
+  <div role="presentation" class="typeahead-empty-suggestions">
+    Suggested users
+  </div>
+  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-selected-end"></li>
+  </ul>
+
+  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-accounts-end"></li>
+  </ul>
+</div>
+
+    <div role="presentation" class="typeahead-dm-conversations">
+  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
+    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
+      <a role="option" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+  </div>
+</div>
+
+  </form>
+</div>
+
+
+  <ul class="nav secondary-nav language-dropdown">
+    <li class="dropdown js-language-dropdown">
+      <a href="#supported_languages" class="dropdown-toggle js-dropdown-toggle">
+        <small>Language:</small> <span class="js-current-language">English</span> <b class="caret"></b>
+      </a>
+      <div class="dropdown-menu">
+        <div class="dropdown-caret right">
+          <span class="caret-outer"> </span>
+          <span class="caret-inner"></span>
+        </div>
+        <ul id="supported_languages">
+            <li><a href="?lang=id" data-lang-code="id" title="Indonesian" class="js-language-link js-tooltip">Bahasa Indonesia</a></li>
+            <li><a href="?lang=msa" data-lang-code="msa" title="Malay" class="js-language-link js-tooltip">Bahasa Melayu</a></li>
+            <li><a href="?lang=ca" data-lang-code="ca" title="Catalan" class="js-language-link js-tooltip">Català</a></li>
+            <li><a href="?lang=cs" data-lang-code="cs" title="Czech" class="js-language-link js-tooltip">Čeština</a></li>
+            <li><a href="?lang=da" data-lang-code="da" title="Danish" class="js-language-link js-tooltip">Dansk</a></li>
+            <li><a href="?lang=de" data-lang-code="de" title="German" class="js-language-link js-tooltip">Deutsch</a></li>
+            <li><a href="?lang=en-gb" data-lang-code="en-gb" title="British English" class="js-language-link js-tooltip">English UK</a></li>
+            <li><a href="?lang=es" data-lang-code="es" title="Spanish" class="js-language-link js-tooltip">Español</a></li>
+            <li><a href="?lang=fil" data-lang-code="fil" title="Filipino" class="js-language-link js-tooltip">Filipino</a></li>
+            <li><a href="?lang=fr" data-lang-code="fr" title="French" class="js-language-link js-tooltip">Français</a></li>
+            <li><a href="?lang=hr" data-lang-code="hr" title="Croatian" class="js-language-link js-tooltip">Hrvatski</a></li>
+            <li><a href="?lang=it" data-lang-code="it" title="Italian" class="js-language-link js-tooltip">Italiano</a></li>
+            <li><a href="?lang=hu" data-lang-code="hu" title="Hungarian" class="js-language-link js-tooltip">Magyar</a></li>
+            <li><a href="?lang=nl" data-lang-code="nl" title="Dutch" class="js-language-link js-tooltip">Nederlands</a></li>
+            <li><a href="?lang=no" data-lang-code="no" title="Norwegian" class="js-language-link js-tooltip">Norsk</a></li>
+            <li><a href="?lang=pl" data-lang-code="pl" title="Polish" class="js-language-link js-tooltip">Polski</a></li>
+            <li><a href="?lang=pt" data-lang-code="pt" title="Portuguese" class="js-language-link js-tooltip">Português</a></li>
+            <li><a href="?lang=ro" data-lang-code="ro" title="Romanian" class="js-language-link js-tooltip">Română</a></li>
+            <li><a href="?lang=sk" data-lang-code="sk" title="Slovak" class="js-language-link js-tooltip">Slovenčina</a></li>
+            <li><a href="?lang=fi" data-lang-code="fi" title="Finnish" class="js-language-link js-tooltip">Suomi</a></li>
+            <li><a href="?lang=sv" data-lang-code="sv" title="Swedish" class="js-language-link js-tooltip">Svenska</a></li>
+            <li><a href="?lang=vi" data-lang-code="vi" title="Vietnamese" class="js-language-link js-tooltip">Tiếng Việt</a></li>
+            <li><a href="?lang=tr" data-lang-code="tr" title="Turkish" class="js-language-link js-tooltip">Türkçe</a></li>
+            <li><a href="?lang=el" data-lang-code="el" title="Greek" class="js-language-link js-tooltip">Ελληνικά</a></li>
+            <li><a href="?lang=bg" data-lang-code="bg" title="Bulgarian" class="js-language-link js-tooltip">Български език</a></li>
+            <li><a href="?lang=ru" data-lang-code="ru" title="Russian" class="js-language-link js-tooltip">Русский</a></li>
+            <li><a href="?lang=sr" data-lang-code="sr" title="Serbian" class="js-language-link js-tooltip">Српски</a></li>
+            <li><a href="?lang=uk" data-lang-code="uk" title="Ukrainian" class="js-language-link js-tooltip">Українська мова</a></li>
+            <li><a href="?lang=he" data-lang-code="he" title="Hebrew" class="js-language-link js-tooltip">עִבְרִית</a></li>
+            <li><a href="?lang=ar" data-lang-code="ar" title="Arabic" class="js-language-link js-tooltip">العربية</a></li>
+            <li><a href="?lang=fa" data-lang-code="fa" title="Persian" class="js-language-link js-tooltip">فارسی</a></li>
+            <li><a href="?lang=mr" data-lang-code="mr" title="Marathi" class="js-language-link js-tooltip">मराठी</a></li>
+            <li><a href="?lang=hi" data-lang-code="hi" title="Hindi" class="js-language-link js-tooltip">हिन्दी</a></li>
+            <li><a href="?lang=bn" data-lang-code="bn" title="Bengali" class="js-language-link js-tooltip">বাংলা</a></li>
+            <li><a href="?lang=gu" data-lang-code="gu" title="Gujarati" class="js-language-link js-tooltip">ગુજરાતી</a></li>
+            <li><a href="?lang=ta" data-lang-code="ta" title="Tamil" class="js-language-link js-tooltip">தமிழ்</a></li>
+            <li><a href="?lang=kn" data-lang-code="kn" title="Kannada" class="js-language-link js-tooltip">ಕನ್ನಡ</a></li>
+            <li><a href="?lang=th" data-lang-code="th" title="Thai" class="js-language-link js-tooltip">ภาษาไทย</a></li>
+            <li><a href="?lang=ko" data-lang-code="ko" title="Korean" class="js-language-link js-tooltip">한국어</a></li>
+            <li><a href="?lang=ja" data-lang-code="ja" title="Japanese" class="js-language-link js-tooltip">日本語</a></li>
+            <li><a href="?lang=zh-cn" data-lang-code="zh-cn" title="Simplified Chinese" class="js-language-link js-tooltip">简体中文</a></li>
+            <li><a href="?lang=zh-tw" data-lang-code="zh-tw" title="Traditional Chinese" class="js-language-link js-tooltip">繁體中文</a></li>
+        </ul>
+      </div>
+      <div class="js-front-language">
+        <form action="/sessions/change_locale" class="t1-form language" method="POST">
+          <input type="hidden" name="lang"> <input type="hidden" name="redirect">
+          <input type="hidden" name="authenticity_token" value="0ff51e342cbaed52729adbdd37fcab367da1e38f">
+        </form>
+      </div>
+    </li>
+  </ul>
+
+    <ul class="nav secondary-nav session-dropdown" id="session">
+      <li class="dropdown js-session">
+          <a href="/login" class="dropdown-toggle js-dropdown-toggle dropdown-signin" id="signin-link" data-nav="login">
+            <small>Have an account?</small> <span class="emphasize"> Log in</span><span class="caret"></span>
+          </a>
+          <div class="dropdown-menu dropdown-form" id="signin-dropdown">
+            <div class="dropdown-caret right"> <span class="caret-outer"></span> <span class="caret-inner"></span> </div>
+            <div class="signin-dialog-body">
+              <div>Have an account?</div>
+              <form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
+  data-component="login_callout"
+  data-element="form"
+>
+  <div class="LoginForm-input LoginForm-username">
+    <input
+      type="text"
+      class="text-input email-input js-signin-email"
+      name="session[username_or_email]"
+      autocomplete="username"
+      placeholder="Phone, email or username"
+    />
+  </div>
+
+  <div class="LoginForm-input LoginForm-password">
+    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
+  </div>
+
+  <div class="LoginForm-rememberForgot">
+    <label>
+      <input type="checkbox" value="1" name="remember_me" checked="checked">
+      <span>Remember me</span>
+    </label>
+    <span class="separator">&middot;</span>
+    <a class="forgot" href="/account/begin_password_reset">Forgot password?</a>
+  </div>
+
+  <input type="submit" class="submit btn primary-btn js-submit" value="Log in">
+
+    <input type="hidden" name="return_to_ssl" value="true">
+
+  <input type="hidden" name="scribe_log">
+  <input type="hidden" name="redirect_after_login" value="/github">
+  <input type="hidden" value="0ff51e342cbaed52729adbdd37fcab367da1e38f" name="authenticity_token">
+</form>
+
+              <hr>
+              <div class="signup SignupForm">
+                <div class="SignupForm-header">New to Twitter?</div>
+                <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn"
+                  data-component="signup_callout"
+                  data-element="dropdown"
+                  >Sign up
+                </a>
+              </div>
+            </div>
+          </div>
+      </li>
+    </ul>
+</div>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+
+        <div id="page-outer">
+          <div id="page-container" class="AppContent">
+              
+            
+
+
+      
+<style id="user-style-github">
+
+
+
+
+
+  a,
+  a:hover,
+  a:focus,
+  a:active {
+    color: #0000FF;
+  }
+
+  .u-textUserColor,
+  .u-textUserColorHover:hover,
+  .u-textUserColorHover:focus {
+    color: #0000FF !important;
+  }
+
+  .u-borderUserColor,
+  .u-borderUserColorHover:hover,
+  .u-borderUserColorHover:focus {
+    border-color: #0000FF !important;
+  }
+
+  .u-bgUserColor,
+  .u-bgUserColorHover:hover,
+  .u-bgUserColorHover:focus {
+    background-color: #0000FF !important;
+  }
+
+
+  .u-dropdownUserColor > li:hover,
+  .u-dropdownUserColor > li:focus,
+  .u-dropdownUserColor > li > button:hover,
+  .u-dropdownUserColor > li > button:focus {
+    color: #fff !important;
+    background-color: #0000FF !important;
+  }
+
+  .u-boxShadowInsetUserColorHover:hover,
+  .u-boxShadowInsetUserColorHover:focus {
+    box-shadow: inset 0 0 0 5px #0000FF !important;
+  }
+
+
+
+  .u-textUserColorLight {
+    color: #9999FF !important;
+  }
+
+  .u-borderUserColorLight,
+  .u-borderUserColorLightFocus:focus,
+  .u-borderUserColorLightHover:hover,
+  .u-borderUserColorLightHover:focus {
+    border-color: #9999FF !important;
+  }
+
+  .u-bgUserColorLight {
+    background-color: #9999FF !important;
+  }
+
+
+  .u-boxShadowUserColorLighterFocus:focus {
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.05), inset 0 1px 2px rgba(0,0,255,0.25) !important;
+  }
+
+
+  .u-textUserColorLightest {
+    color: #E5E5FF !important;
+  }
+
+  .u-borderUserColorLightest {
+    border-color: #E5E5FF !important;
+  }
+
+  .u-bgUserColorLightest {
+    background-color: #E5E5FF !important;
+  }
+
+
+  .u-textUserColorLighter {
+    color: #BFBFFF !important;
+  }
+
+  .u-borderUserColorLighter {
+    border-color: #BFBFFF !important;
+  }
+
+  .u-bgUserColorLighter {
+    background-color: #BFBFFF !important;
+  }
+
+
+  .u-bgUserColorDarkHover:hover {
+    background-color: #0000CC !important;
+  }
+
+  .u-borderUserColorDark {
+    border-color: #0000CC !important;
+  }
+
+
+  .u-bgUserColorDarkerActive:active {
+    background-color: #000099 !important;
+  }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+a,
+.btn-link,
+.btn-link:focus,
+.icon-btn,
+
+
+
+.pretty-link b,
+.pretty-link:hover s,
+.pretty-link:hover b,
+.pretty-link:focus s,
+.pretty-link:focus b,
+/* Account Group */
+.metadata a:hover,
+.metadata a:focus,
+
+.account-group:hover .fullname,
+.account-group:focus .fullname,
+.account-summary:focus .fullname,
+
+.message .message-text a,
+.stats a strong,
+.plain-btn:hover,
+.plain-btn:focus,
+.dropdown.open .user-dropdown.plain-btn,
+.open > .plain-btn,
+#global-actions .new:before,
+.module .list-link:hover,
+.module .list-link:focus,
+
+.stats a:hover,
+.stats a:hover strong,
+.stats a:focus,
+.stats a:focus strong,
+
+.profile-modal-header .fullname a:hover,
+.profile-modal-header .username a:hover,
+.profile-modal-header .fullname a:focus,
+.profile-modal-header .username a:focus,
+
+.find-friends-sources li:hover .source,
+
+
+
+
+
+.stream-item a:hover .fullname,
+.stream-item a:focus .fullname,
+
+.stream-item .view-all-supplements:hover,
+.stream-item .view-all-supplements:focus,
+
+.tweet .time a:hover,
+.tweet .time a:focus,
+.tweet .details.with-icn b,
+.tweet .details.with-icn .Icon,
+.tweet .tweet-geo-text a:hover,
+
+.stream-item:hover .original-tweet .details b,
+.stream-item .original-tweet.focus .details b,
+.stream-item.open .original-tweet .details b,
+
+.client-and-actions a:hover,
+.client-and-actions a:focus,
+
+.dismiss-btn:hover b,
+
+.tweet .context .pretty-link:hover s,
+.tweet .context .pretty-link:hover b,
+.tweet .context .pretty-link:focus s,
+.tweet .context .pretty-link:focus b,
+
+.list .username a:hover,
+.list .username a:focus,
+.list-membership-container .create-a-list,
+.list-membership-container .create-a-list:hover,
+
+
+
+.card .list-details a:hover,
+.card .list-details a:focus,
+.card .card-body:hover .attribution,
+.card .card-body .attribution:focus,
+.new-tweets-bar,
+.onebox .soccer ul.ticker a:hover,
+.onebox .soccer ul.ticker a:focus,
+
+
+
+.remove-background-btn,
+
+
+
+.stream-item-activity-notification .latest-tweet .tweet-row a:hover,
+.stream-item-activity-notification .latest-tweet .tweet-row a:focus,
+.stream-item-activity-notification .latest-tweet .tweet-row a:hover b,
+.stream-item-activity-notification .latest-tweet .tweet-row a:focus b {
+    color: #0000FF;
+}
+
+
+
+
+  /* hover state for found media items */
+  .FoundMediaSearch--keyboard .FoundMediaSearch-focusable.is-focused {
+    border-color: #0000FF;
+  }
+
+  /* hover state for photo select button*/
+  .photo-selector:hover .btn,
+  .icon-btn:hover,
+  .icon-btn:active,
+  .icon-btn.active,
+  .icon-btn.enabled {
+    border-color: #0000FF;
+    border-color: rgba(0,0,255,.5);
+    color: #0000FF;
+  }
+
+  /* hover state for photo select button*/
+  .photo-selector:hover .btn,
+  .icon-btn:hover {
+    background-image: linear-gradient(rgba(255,255,255,0), rgba(0,0,255,.1));
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00FFFFFF', endColorstr='#190000FF'); /* IE8-9 */
+  }
+
+  .icon-btn.disabled,
+  .icon-btn.disabled:hover,
+  .icon-btn[disabled],
+  .icon-btn[aria-disabled=true] {
+    color: #0000FF;
+  }
+
+  /* tweet-btn can have primary-btn class as well so the following rules ensure that the correct background color is applied */
+  .tweet-btn,
+  .tweet-btn:focus {
+    background-color: #0000FF;
+    background: rgba(0,0,255,.8);
+  }
+
+  .tweet-btn:hover,
+  .tweet-btn:active,
+  .tweet-btn.active {
+    background-color: #0000FF;
+  }
+
+  .tweet-btn.btn.disabled,
+  .tweet-btn.btn.disabled:hover,
+  .tweet-btn.btn[disabled],
+  .tweet-btn.btn[aria-disabled=true] {
+    background: #0000FF;
+  }
+
+  .btn:focus,
+  .btn.focus,
+  .Button:focus {
+    box-shadow:
+      0 0 0 1px #fff,
+      0 0 0 3px rgba(0, 0, 255, 0.5);
+  }
+
+  .selected-stream-item:focus {
+    box-shadow: 0 0 0 3px rgba(0, 0, 255, 0.5);
+  }
+
+  /* highlighting when navigate through timeline stream table view with j & k. */
+  .js-navigable-stream.stream-table-view .selected-stream-item[tabindex="-1"]:focus {
+    outline: 3px solid rgba(0, 0, 255, 0.5) !important;
+  }
+
+  /* box-shadow does not work with table tr element */
+  .js-navigable-stream.stream-table-view .selected-stream-item:focus {
+    box-shadow: none;
+  }
+
+  /**
+   * 1. Bring actionable tweet to top when active to ensure border
+   *    highlighting wraps entire tweet. Value must be at least at if not
+   *    higher than the z-index value of ProfileHeading to ensure first
+   *    tweet in timeline receives border on all four sides.
+   *    NOTE: z-index should be 2 to avoid conflicts with .ProfileCanopy and .ProfileCard-avatarLink
+   */
+
+  .js-stream-item.is-selected:focus .ProfileCard,
+  .QuoteTweet:hover,
+  .QuoteTweet:focus,
+  .QuoteTweet:active,
+  .activity-user-profile-content:hover,
+  .activity-user-profile-content:focus,
+  .activity-user-profile-content:active {
+    border-color: rgba(0, 0, 255, 0.5);
+    z-index: 2; /* 1 */
+  }
+
+  .global-dm-nav.new.with-count .dm-new {
+    background: #fff;
+  }
+
+  .global-dm-nav.new.with-count .dm-new .count-inner {
+    background: #0000FF;
+  }
+
+  .global-nav .people .count .count-inner {
+    background: #0000FF;
+  }
+
+  .dropdown-menu li > a:hover,
+  .dropdown-menu li > a:focus,
+  .dropdown-menu .dropdown-link:hover,
+  .dropdown-menu .dropdown-link:focus,
+  .dropdown-menu .dropdown-link.is-focused,
+  .dropdown-menu li:hover .dropdown-link,
+  .dropdown-menu li:focus .dropdown-link,
+  .dropdown-menu .typeahead-recent-search-item.selected,
+  .dropdown-menu .typeahead-saved-search-item.selected,
+  .dropdown-menu .selected a,
+  .dropdown-menu .dropdown-link.selected {
+    background-color: #0000FF !important;
+  }
+
+/* give tweet boxes 10% of the users link color as background */
+.home-tweet-box,
+.RetweetDialog-commentBox,
+.WebToast-box--altColor,
+.content-main .conversations-enabled .expansion-container .inline-reply-tweetbox {
+  background-color: #E5E5FF;
+}
+
+.conversations-enabled .inline-reply-caret .caret-inner {
+  border-bottom-color: #E5E5FF;
+}
+.top-timeline-tweetbox .timeline-tweet-box .tweet-form.condensed .tweet-box {
+  color: #0000FF;
+}
+/* give tweet box containers an outline using the users link color */
+.RichEditor {
+  border-color: #BFBFFF;
+}
+/* give tweet boxes an outline using the users link color */
+.tweet-compose-errors {
+  border-color: rgba(0,0,255,0.25);
+}
+
+input:focus,
+textarea:focus,
+div[contenteditable="true"]:focus,
+div[contenteditable="true"].fake-focus {
+  border-color: #6666FF;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 255, 0.7);
+}
+
+.tweet-box textarea:focus,
+.tweet-box input[type=text],
+.currently-dragging .tweet-form.is-droppable .tweet-drag-help,
+.tweet-box[contenteditable="true"]:focus,
+.RichEditor.is-fakeFocus {
+  border-color: #9999FF;
+  box-shadow: none;
+}
+
+
+
+
+s,
+.pretty-link:hover s,
+.pretty-link:focus s,
+.stream-item-activity-notification .latest-tweet .tweet-row a:hover s,
+.stream-item-activity-notification .latest-tweet .tweet-row a:focus s {
+    color: #0000FF;
+}
+
+
+
+.vellip,
+.vellip:before,
+.vellip:after,
+.conversation-module > li:after,
+.conversation-module > li:before,
+.ThreadedConversation-tweet ~ .ThreadedConversation-tweet:before,
+.ThreadedConversation-tweet:after,
+.ThreadedConversation-viewOther:before,
+.ThreadedConversation-unavailableTweet:before,
+.ThreadedConversation-unavailableTweet:after {
+    background-color: #6666FF;
+}
+
+
+
+
+.tweet .sm-reply,
+.tweet .sm-rt,
+.tweet .sm-fav,
+.tweet .sm-image,
+.tweet .sm-video,
+.tweet .sm-audio,
+.tweet .sm-geo,
+.tweet .sm-in,
+.tweet .sm-trash,
+.tweet .sm-more,
+.tweet .sm-page,
+.tweet .sm-embed,
+.tweet .sm-summary,
+.tweet .sm-chat,
+
+.timelines-navigation .active .profile-nav-icon,
+.timelines-navigation .profile-nav-icon:hover,
+.timelines-navigation .profile-nav-link:focus .profile-nav-icon,
+
+.sm-top-tweet,
+
+.metadata a.tweet-geo-text:hover .sm-geo {
+    background-color: #0000FF;
+}
+
+.enhanced-mini-profile .mini-profile .profile-summary {
+  background-image: url(https://pbs.twimg.com/profile_banners/13334762/1415719104/mobile);
+}
+
+.wrapper-profile .profile-card.profile-header .profile-header-inner {
+  background-image: url(https://pbs.twimg.com/profile_banners/13334762/1415719104/web);
+}
+
+  #global-tweet-dialog .modal-header {
+    border-bottom: solid 1px rgba(0, 0, 255, .25);
+  }
+
+  #global-tweet-dialog .modal-tweet-form-container {
+    background-color: #0000FF;
+    background: rgba(0, 0, 255, .1);
+  }
+
+  .inline-reply-tweetbox {
+    background-color: #E5E5FF;
+  }
+
+</style>
+
+
+    <div class="ProfileCanopy ProfileCanopy--withNav ProfileCanopy--large">
+  <div class="ProfileCanopy-inner">
+
+    <div class="ProfileCanopy-header u-bgUserColor">
+    <div class="ProfileCanopy-headerBg">
+      <img alt=""
+        src="https://pbs.twimg.com/profile_banners/13334762/1415719104/1500x500"
+        
+      >
+    </div>
+
+  <div class="AppContainer">
+
+    <div class="ProfileCanopy-avatar">
+      <div class="ProfileAvatar">
+    <a class="ProfileAvatar-container u-block js-tooltip profile-picture"
+        href="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+        title="GitHub"
+        data-resolved-url-large="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+        data-url="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+        target="_blank">
+      <img class="ProfileAvatar-image " src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_400x400.png" alt="GitHub">
+    </a>
+</div>
+
+    </div>
+
+
+    <div class="ProfileCanopy-headerPromptAnchor"></div>
+  </div>
+
+</div>
+
+
+    <div class="ProfileCanopy-navBar">
+      
+      <div class="AppContainer">
+        <div class="Grid Grid--withGutter">
+          <div class="Grid-cell u-size1of3 u-lg-size1of4">
+            <div class="ProfileCanopy-card" role="presentation">
+              <div class="ProfileCardMini">
+  <a class="ProfileCardMini-avatar profile-picture js-tooltip"
+     href="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+     title="GitHub"
+     data-resolved-url-large="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+     data-url="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ.png"
+     target="_blank">
+    <img class="ProfileCardMini-avatarImage" alt="GitHub" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_normal.png" >
+  </a>
+  <div class="ProfileCardMini-details">
+    <div class="ProfileNameTruncated">
+  <div class="u-textTruncate u-inlineBlock ProfileNameTruncated-withBadges ProfileNameTruncated-withBadges--1">
+    <a class="ProfileNameTruncated-link u-textInheritColor js-nav js-action-profile-name" href="/github"  data-aria-label-part>
+      GitHub
+    </a>
+      <div class="ProfileNameTruncated-badges">
+        <a href="/help/verified" class="js-tooltip" target="_blank" title="Verified account" data-placement="right"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></a>
+
+      </div>
+  </div>
+</div>
+    <div class="ProfileCardMini-screenname">
+      <a href="/github" class="ProfileCardMini-screennameLink u-linkComplex js-nav u-dir" dir="ltr">@<span class="u-linkComplex-target">github</span></a>
+    </div>
+  </div>
+</div>
+
+            </div>
+          </div>
+
+          <div class="Grid-cell u-size2of3 u-lg-size3of4">
+            <div class="ProfileCanopy-nav">
+              
+  <div class="ProfileNav" role="navigation" data-user-id="13334762">
+    <ul class="ProfileNav-list">
+<li class="ProfileNav-item ProfileNav-item--tweets is-active">
+          <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-nav" title="3,230 Tweets" data-nav="tweets"
+              tabindex=0
+>
+            <span class="ProfileNav-label">Tweets</span>
+            <span class="ProfileNav-value" data-is-compact="false">3,230</span>
+          </a>
+        </li><li class="ProfileNav-item ProfileNav-item--following">
+        <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-openSignupDialog js-nonNavigable u-textUserColor" title="192 Following" data-nav="following"
+            href="/github/following"
+>
+          <span class="ProfileNav-label">Following</span>
+          <span class="ProfileNav-value" data-is-compact="false">192</span>
+        </a>
+      </li><li class="ProfileNav-item ProfileNav-item--followers">
+        <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-openSignupDialog js-nonNavigable u-textUserColor" title="842,686 Followers" data-nav="followers"
+            href="/github/followers"
+>
+          <span class="ProfileNav-label">Followers</span>
+          <span class="ProfileNav-value" data-is-compact="true">843K</span>
+        </a>
+      </li><li class="ProfileNav-item ProfileNav-item--favorites" data-more-item=".ProfileNav-dropdownItem--favorites">
+        <a class="ProfileNav-stat ProfileNav-stat--link u-borderUserColor u-textCenter js-tooltip js-openSignupDialog js-nonNavigable u-textUserColor" title="160 Likes" data-nav="favorites"
+            href="/github/likes"
+>
+          <span class="ProfileNav-label">Likes</span>
+          <span class="ProfileNav-value" data-is-compact="false">160</span>
+        </a>
+      </li><li class="ProfileNav-item ProfileNav-item--more dropdown is-hidden">        <a class="ProfileNav-stat ProfileNav-stat--link ProfileNav-stat--moreLink js-openSignupDialog js-nonNavigable" href="#more">
+          <span class="ProfileNav-label">&nbsp;</span>
+          <span class="ProfileNav-value">More <span class="ProfileNav-dropdownCaret Icon Icon--caretDown"></span></span>
+        </a>
+        <div class="dropdown-menu">
+          <div class="dropdown-caret">
+            <span class="caret-outer"></span>
+            <span class="caret-inner"></span>
+          </div>
+          <ul><li>
+              <a href="/github/likes" class="ProfileNav-dropdownItem ProfileNav-dropdownItem--favorites is-hidden u-bgUserColorHover u-bgUserColorFocus u-linkClean js-nav">Likes</a></li></ul>
+        </div>
+      </li><li class="ProfileNav-item ProfileNav-item--userActions u-floatRight u-textRight with-rightCaret ">
+        <div class="UserActions   u-textLeft" >
+    <div class="user-actions btn-group not-following " data-user-id="13334762"
+        data-screen-name="github" data-name="GitHub" data-protected="false">
+      <span class="UserActions-moreActions u-inlineBlock">
+          <button type="button" class="js-tooltip unmute-button btn small plain-btn" title="Unmute @github" data-placement="top">
+            <span class="Icon Icon--muted Icon--medium"><span class="visuallyhidden">Unmute @github</span></span>
+          </button><button type="button" class="first-load js-tooltip mute-button btn small plain-btn" title="Mute @github" data-placement="top">
+            <span class="Icon Icon--unmuted Icon--medium"><span class="visuallyhidden">Mute @github</span></span>
+          </button>
+
+      </span><button class="user-actions-follow-button js-follow-btn follow-button btn" type="button">
+  <span class="button-text follow-text">
+     <span class="Icon Icon--follow"></span> Follow 
+    
+  </span>
+  <span class="button-text following-text">
+     Following 
+    
+  </span>
+  <span class="button-text unfollow-text">
+     Unfollow 
+    
+  </span>
+  <span class="button-text blocked-text">Blocked</span>
+  <span class="button-text unblock-text">Unblock</span>
+  <span class="button-text pending-text">Pending</span>
+  <span class="button-text cancel-text">Cancel</span>
+</button>
+
+    </div>
+</div>
+
+      </li>
+    </ul>
+  </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+
+
+    <div class="AppContainer">
+      <div class="AppContent-main content-main u-cf" role="main" aria-labelledby="content-main-heading">
+        <div class="Grid Grid--withGutter">
+          <div class="Grid-cell u-size1of3 u-lg-size1of4">
+            <div class="Grid Grid--withGutter">
+              <div class="Grid-cell">
+                <div class="ProfileSidebar ProfileSidebar--withLeftAlignment">
+  <div class="ProfileHeaderCard">
+  <h1 class="ProfileHeaderCard-name">
+    <a href="/github"
+       class="ProfileHeaderCard-nameLink u-textInheritColor js-nav
+         ProfileHeaderCard-nameWithBadges--1
+">GitHub</a><span class="ProfileHeaderCard-badges ProfileHeaderCard-badges--1"><a href="/help/verified" class="js-tooltip" target="_blank" title="Verified account" data-placement="right"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></a>
+</span>
+  </h1>
+
+  <h2 class="ProfileHeaderCard-screenname u-inlineBlock u-dir" dir="ltr">
+    <a class="ProfileHeaderCard-screennameLink u-linkComplex js-nav" href="/github">@<span class="u-linkComplex-target">github</span></a>
+  </h2>
+
+    <p class="ProfileHeaderCard-bio u-dir"
+      
+      dir="ltr">How people build software</p>
+
+      <div class="ProfileHeaderCard-location">
+        <span class="Icon Icon--geo Icon--medium"></span>
+        <span class="ProfileHeaderCard-locationText u-dir" dir="ltr">
+            San Francisco, CA
+        </span>
+      </div>
+
+      <div class="ProfileHeaderCard-url ">
+        <span class="Icon Icon--url Icon--medium"></span>
+        <span class="ProfileHeaderCard-urlText u-dir" dir="ltr">  <a class="u-textUserColor" target="_blank" rel="me nofollow" href="https://t.co/FoKGHcCyJJ" title="https://github.com">
+    github.com
+  </a>
+
+</span>
+      </div>
+
+
+      <div class="ProfileHeaderCard-joinDate">
+        <span class="Icon Icon--calendar Icon--small"></span>
+        <span class="ProfileHeaderCard-joinDateText js-tooltip u-dir" dir="ltr" title="8:41 PM - 10 Feb 2008">Joined February 2008</span>
+      </div>
+
+    <div class="ProfileHeaderCard-birthdate u-hidden">
+      <span class="Icon Icon--balloon Icon--medium"></span>
+      <span class="ProfileHeaderCard-birthdateText u-dir" dir="ltr">
+</span>
+    </div>
+
+</div>
+
+
+
+
+
+
+
+      <div class="PhotoRail">
+  <div class="PhotoRail-heading">
+    <span class="Icon Icon--camera Icon--medium u-alignBottom"></span>
+    <span class="PhotoRail-headingText">
+            <a href="/github/media" class="PhotoRail-headingWithCount js-nav">
+                
+                46 Photos and videos
+            </a>
+          <a href="/github/media" class="PhotoRail-headingWithoutCount js-nav">
+            Photos and videos
+          </a>
+    </span>
+  </div>
+  <div class="PhotoRail-mediaBox">
+    <span class="js-photoRailInsertPoint"></span>
+  </div>
+</div>
+
+
+
+</div>
+
+              </div>
+            </div>
+          </div>
+
+          <div class="Grid-cell u-size2of3 u-lg-size3of4">
+            <div class="Grid Grid--withGutter">
+                <div class="Grid-cell">
+                  <div class="js-profileClusterFollow"></div>
+                </div>
+
+              <div class="Grid-cell
+                    u-lg-size2of3
+              " data-test-selector="ProfileTimeline">
+                  
+                    <div class="ProfileHeading">
+  <div class="ProfileHeading-spacer"></div>
+    <div class="ProfileHeading-content">
+      <h2 id="content-main-heading" class="ProfileHeading-title u-hiddenVisually ">Tweets</h2>
+        <ul class="ProfileHeading-toggle">
+            <li class="ProfileHeading-toggleItem
+              
+              is-active
+              "
+              data-element-term="tweets_toggle">
+                Tweets
+            </li>
+            <li class="ProfileHeading-toggleItem
+              
+              
+              u-textUserColor"
+              data-element-term="tweets_with_replies_toggle">
+                <a class="ProfileHeading-toggleLink js-nav" href="/github/with_replies" data-nav="tweets_with_replies_toggle">
+                  Tweets &amp; replies
+                </a>
+            </li>
+            <li class="ProfileHeading-toggleItem
+              
+              
+              u-textUserColor"
+              data-element-term="photos_and_videos_toggle">
+                <a class="ProfileHeading-toggleLink js-nav" href="/github/media" data-nav="photos_and_videos_toggle">
+                  Media
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+
+                  <div class="BlockedWarningTimeline">
+  <h2 class="BlockedWarningTimeline-heading" id="content-main-heading">@github is blocked</h2>
+  <p class="BlockedWarningTimeline-explanation">Are you sure you want to view these Tweets? Viewing Tweets won't unblock @github.</p>
+
+  <button class="btn BlockedWarningTimeline-button">View Tweets</button>
+</div>
+                  
+
+
+
+
+  <div id="scroll-bump-dialog" class="ScrollBumpDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content clearfix">
+
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">
+            
+            GitHub followed
+        </h3>
+      </div>
+
+      <div class="modal-body">
+        <div class="loading">
+          <span class="spinner-bigger"></span>
+        </div>
+        <ol class="ScrollBumpDialog-usersList clearfix js-users-list"></ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+
+    <div id="timeline" class="ProfileTimeline ">
+        <div class="stream-container  "
+    data-max-position="730419214251642880" data-min-position="714522458494140416"
+    >
+
+      <div class="stream-item js-new-items-bar-container">
+</div>
+
+    <div class="stream">
+        <ol class="stream-items js-navigable-stream" id="stream-items-id">
+          
+      <li class="js-stream-item stream-item stream-item expanding-stream-item js-pinned
+" data-item-id="730292560074153985" id="stream-item-tweet-730292560074153985" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward user-pinned
+"
+      
+data-tweet-id="730292560074153985"
+data-item-id="730292560074153985"
+data-permalink-path="/github/status/730292560074153985"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:04 AM - 11 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730292560074153985&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+          <div class="tweet-context with-icn
+    
+     pinned">
+
+      <span class="Icon Icon--small Icon--pinned u-textUserColor"></span>
+
+
+
+
+
+
+
+      
+
+        <span class="js-pinned-text" data-aria-label-part>Pinned Tweet</span>
+
+
+    </div>
+
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730292560074153985" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:04 AM - 11 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462950289" data-time-ms="1462950289000" data-long-form="true">May 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Unlimited private repositories. Unlimited possibilities:<a href="https://t.co/nxtv667Qk6" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2164-introducing-unlimited-private-repositories?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=ww-unlimited-private-repos-20160511" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2164-introducing-unlimited-private-repositories?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=ww-unlimited-private-repos-20160511" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2164-intr</span><span class="invisible">oducing-unlimited-private-repositories?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=ww-unlimited-private-repos-20160511</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730292560074153985?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/nxtv667Qk6"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730292560074153985?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:04 AM - 11 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730292560074153985"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="2176">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>2,176 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="2020">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>2,020 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2.2K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2.2K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730412664208265216" id="stream-item-tweet-730412664208265216" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730412664208265216"
+data-item-id="730412664208265216"
+data-permalink-path="/github/status/730412664208265216"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="player"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;8:02 AM - 11 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730412664208265216&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730412664208265216" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:02 AM - 11 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462978924" data-time-ms="1462978924000" data-long-form="true">May 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Building cross-platform desktop apps has never been easier. Learn how with Electron:<a href="https://t.co/5iojwiY6X8" rel="nofollow" dir="ltr" data-expanded-url="https://www.youtube.com/watch?v=8YP_nOCO-4Q" class="twitter-timeline-link u-hidden" target="_blank" title="https://www.youtube.com/watch?v=8YP_nOCO-4Q" ><span class="tco-ellipsis"></span><span class="invisible">https://www.</span><span class="js-display-url">youtube.com/watch?v=8YP_nO</span><span class="invisible">CO-4Q</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="player"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-player"
+  data-src="/i/cards/tfw/v1/730412664208265216?cardname=player&amp;earned=true&amp;lang=en"
+  data-card-name="player"
+  data-card-url="https://t.co/5iojwiY6X8"
+  data-publisher-id="10228272"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730412664208265216?cardname=player&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:02 AM - 11 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730412664208265216"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="104">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>104 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="204">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>204 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">104</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">104</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">204</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">204</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730298546189160448" id="stream-item-tweet-730298546189160448" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730298546189160448"
+data-item-id="730298546189160448"
+data-permalink-path="/github/status/730298546189160448"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="defunkt"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:28 AM - 11 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730298546189160448&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730298546189160448" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:28 AM - 11 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462951716" data-time-ms="1462951716000" data-long-form="true">May 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Check out the stream of all <a href="/hashtag/SatelliteAMS?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>SatelliteAMS</b></a> talks! <a href="/defunkt" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="713263" ><s>@</s><b>defunkt</b></a>&#39;s opening session begins momentarily:<a href="https://t.co/BmE2t7UdI5" rel="nofollow" dir="ltr" data-expanded-url="http://githubuniverse.com/satellite/" class="twitter-timeline-link u-hidden" target="_blank" title="http://githubuniverse.com/satellite/" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">githubuniverse.com/satellite/</span><span class="invisible"></span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730298546189160448?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/BmE2t7UdI5"
+  data-publisher-id=""
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730298546189160448?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:28 AM - 11 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730298546189160448"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="48">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>48 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="44">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>44 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730290559038840832" id="stream-item-tweet-730290559038840832" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730290559038840832"
+data-item-id="730290559038840832"
+data-permalink-path="/github/status/730290559038840832"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:56 PM - 10 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730290559038840832&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730290559038840832" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:56 PM - 10 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462949812" data-time-ms="1462949812000" data-long-form="true">May 10</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Meet Electron 1.0, the best way to build desktop apps with JavaScript, HTML, and CSS... available today:<a href="https://t.co/UKXg1wpVQT" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2167-electron-1-0-is-here" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2167-electron-1-0-is-here" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2167-elec</span><span class="invisible">tron-1-0-is-here</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730290559038840832?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/UKXg1wpVQT"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730290559038840832?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:56 PM - 10 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730290559038840832"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="577">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>577 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="756">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>756 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">756</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">756</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730115766163509248" id="stream-item-tweet-730115766163509248" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730115766163509248"
+data-item-id="730115766163509248"
+data-permalink-path="/github/status/730115766163509248"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:22 PM - 10 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730115766163509248&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730115766163509248" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:22 PM - 10 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462908138" data-time-ms="1462908138000" data-long-form="true">May 10</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Better discoverability for GitHub Pages sites<a href="https://t.co/R52dOcSpte" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2162-better-discoverability-for-github-pages-sites" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2162-better-discoverability-for-github-pages-sites" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2162-bett</span><span class="invisible">er-discoverability-for-github-pages-sites</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/730115766163509248?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/R52dOcSpte"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730115766163509248?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:22 PM - 10 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730115766163509248"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="75">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>75 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="122">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>122 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">75</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">75</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">122</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">122</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="730101446423633921" id="stream-item-tweet-730101446423633921" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="730101446423633921"
+data-item-id="730101446423633921"
+data-permalink-path="/github/status/730101446423633921"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:25 AM - 10 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/730101446423633921&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/730101446423633921" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:25 AM - 10 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462904724" data-time-ms="1462904724000" data-long-form="true">May 10</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Introducing a darker side to GitHub Desktop—a new, dark theme is now available on Windows:<a href="https://t.co/YE2Glujl7a" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2169-github-desktop-now-has-a-dark-side" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2169-github-desktop-now-has-a-dark-side" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2169-gith</span><span class="invisible">ub-desktop-now-has-a-dark-side</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/730101446423633921?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/YE2Glujl7a"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/730101446423633921?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:25 AM - 10 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/730101446423633921"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="180">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>180 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="359">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>359 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">359</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">359</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="729788404561489924" id="stream-item-tweet-729788404561489924" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="729788404561489924"
+data-item-id="729788404561489924"
+data-permalink-path="/github/status/729788404561489924"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;2:41 PM - 9 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/729788404561489924&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/729788404561489924" class="tweet-timestamp js-permalink js-nav js-tooltip" title="2:41 PM - 9 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462830089" data-time-ms="1462830089000" data-long-form="true">May 9</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Please join us for a Patchwork in Chicago on May 24:<a href="https://t.co/jKcckqIfUw" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2168-patchwork-chicago" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2168-patchwork-chicago" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2168-patc</span><span class="invisible">hwork-chicago</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/729788404561489924?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/jKcckqIfUw"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/729788404561489924?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>2:41 PM - 9 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/729788404561489924"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="20">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>20 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="729589015435948032" id="stream-item-tweet-729589015435948032" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="729589015435948032"
+data-item-id="729589015435948032"
+data-permalink-path="/github/status/729589015435948032"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;1:29 AM - 9 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/729589015435948032&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/729589015435948032" class="tweet-timestamp js-permalink js-nav js-tooltip" title="1:29 AM - 9 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462782551" data-time-ms="1462782551000" data-long-form="true">May 9</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Amsterdam and Paris friends, please join us for meetups on 10 and 12 May:<a href="https://t.co/NkYVM1mSPx" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2166-atom-and-electron-meetups-in-amsterdam-and-paris" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2166-atom-and-electron-meetups-in-amsterdam-and-paris" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2166-atom</span><span class="invisible">-and-electron-meetups-in-amsterdam-and-paris</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/729589015435948032?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/NkYVM1mSPx"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/729589015435948032?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>1:29 AM - 9 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/729589015435948032"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="70">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>70 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">70</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">70</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="728107437891293187" id="stream-item-tweet-728107437891293187" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="728107437891293187"
+data-item-id="728107437891293187"
+data-permalink-path="/github/status/728107437891293187"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:21 PM - 4 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/728107437891293187&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/728107437891293187" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:21 PM - 4 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462429315" data-time-ms="1462429315000" data-long-form="true">May 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Satellite is next week and we&#39;re almost sold out. Grab a ticket while you can and join us in Amsterdam: <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="43">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>43 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="52">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>52 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">52</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">52</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="727556156273512449" id="stream-item-tweet-727556156273512449" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="727556156273512449"
+data-item-id="727556156273512449"
+data-permalink-path="/github/status/727556156273512449"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/727556156273512449" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:51 AM - 3 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462297879" data-time-ms="1462297879000" data-long-form="true">May 3</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">You can now import repositories with large files from other version control systems: <a href="https://t.co/cyXGXgPNZz" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2163-import-repositories-with-large-files?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=2163-import-repositories-with-large-files" class="twitter-timeline-link" target="_blank" title="https://github.com/blog/2163-import-repositories-with-large-files?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=2163-import-repositories-with-large-files" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2163-impo</span><span class="invisible">rt-repositories-with-large-files?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=2163-import-repositories-with-large-files</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a><a href="https://t.co/mct8X8eBdN" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/mct8X8eBdN</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      allow-expansion
+      
+      is-square
+      is-generic-video
+      
+      has-autoplayable-media"
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-video">
+  <div class="AdaptiveMedia-videoContainer">
+      <div class="PlayableMedia PlayableMedia--gif">
+
+  <div
+    class="PlayableMedia-player
+      
+      
+      "
+    data-playable-media-url=""
+    style="padding-bottom: 38.666666666666664%; background-image:url('https://pbs.twimg.com/tweet_video_thumb/ChjMX6QU4AAJ7Ze.jpg')">
+  </div>
+
+  
+  
+</div>
+
+  </div>
+</div>
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:51 AM - 3 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/727556156273512449"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="181">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>181 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="215">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>215 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">181</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">181</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="727281796044455937" id="stream-item-tweet-727281796044455937" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="727281796044455937"
+data-item-id="727281796044455937"
+data-permalink-path="/github/status/727281796044455937"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="IBM vangoghmuseum"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;4:41 PM - 2 May 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/727281796044455937&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/727281796044455937" class="tweet-timestamp js-permalink js-nav js-tooltip" title="4:41 PM - 2 May 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1462232467" data-time-ms="1462232467000" data-long-form="true">May 2</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Github Satellite sponsor <a href="/IBM" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="18994444" ><s>@</s><b>IBM</b></a> has a new blog detailing the event and after party <a href="/vangoghmuseum" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="24691376" ><s>@</s><b>vangoghmuseum</b></a>. Details here:<a href="https://t.co/rr8DFT52bC" rel="nofollow" dir="ltr" data-expanded-url="https://developer.ibm.com/dwblog/ibm-is-sponsoring-the-github-satellite-conference/" class="twitter-timeline-link u-hidden" target="_blank" title="https://developer.ibm.com/dwblog/ibm-is-sponsoring-the-github-satellite-conference/" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">developer.ibm.com/dwblog/ibm-is-</span><span class="invisible">sponsoring-the-github-satellite-conference/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/727281796044455937?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/rr8DFT52bC"
+  data-publisher-id="16362921"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/727281796044455937?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>4:41 PM - 2 May 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/727281796044455937"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="33">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>33 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="57">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>57 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">57</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">57</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="726065354263252992" id="stream-item-tweet-726065354263252992" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="726065354263252992"
+data-item-id="726065354263252992"
+data-permalink-path="/github/status/726065354263252992"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;8:07 AM - 29 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/726065354263252992&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/726065354263252992" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:07 AM - 29 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461942444" data-time-ms="1461942444000" data-long-form="true">Apr 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Get insights from GitHub customers, community, and leaders at Satellite<a href="https://t.co/f0eeNYr2h4" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2161-get-insights-from-github-customers-community-and-leaders-at-satellite" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2161-get-insights-from-github-customers-community-and-leaders-at-satellite" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2161-get-</span><span class="invisible">insights-from-github-customers-community-and-leaders-at-satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/726065354263252992?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/f0eeNYr2h4"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/726065354263252992?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:07 AM - 29 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/726065354263252992"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="21">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>21 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="31">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>31 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">21</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">21</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="725575239187329024" id="stream-item-tweet-725575239187329024" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="725575239187329024"
+data-item-id="725575239187329024"
+data-permalink-path="/github/status/725575239187329024"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="githubuniverse"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:39 PM - 27 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/725575239187329024&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/725575239187329024" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:39 PM - 27 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461825592" data-time-ms="1461825592000" data-long-form="true">Apr 27</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Only two weeks left until GitHub Satellite, the first international conference in the <a href="/githubuniverse" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="2980633674" ><s>@</s><b>githubuniverse</b></a> event series: <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="32">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>32 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="67">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>67 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="725015353034723329" id="stream-item-tweet-725015353034723329" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="725015353034723329"
+data-item-id="725015353034723329"
+data-permalink-path="/github/status/725015353034723329"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;10:35 AM - 26 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/725015353034723329&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/725015353034723329" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:35 AM - 26 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461692104" data-time-ms="1461692104000" data-long-form="true">Apr 26</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Enterprise 2.6 is here with templates and pre-receive hooks to help your team work smarter. See what&#39;s new:<a href="https://t.co/R3zThLcT0H" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2157-github-enterprise-2-6-is-here-with-faster-more-approachable-workflows?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=enterprise-2.6-release" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2157-github-enterprise-2-6-is-here-with-faster-more-approachable-workflows?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=enterprise-2.6-release" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2157-gith</span><span class="invisible">ub-enterprise-2-6-is-here-with-faster-more-approachable-workflows?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=enterprise-2.6-release</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/725015353034723329?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/R3zThLcT0H"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/725015353034723329?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:35 AM - 26 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/725015353034723329"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="115">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>115 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="141">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>141 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">115</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">115</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">141</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">141</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="724978829815648256" id="stream-item-tweet-724978829815648256" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="724978829815648256"
+data-item-id="724978829815648256"
+data-permalink-path="/github/status/724978829815648256"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;8:09 AM - 26 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/724978829815648256&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/724978829815648256" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:09 AM - 26 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461683397" data-time-ms="1461683397000" data-long-form="true">Apr 26</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Technical writers, join us for a special Patchwork in Atlanta on May 6:<a href="https://t.co/LAKRnaNuii" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2160-patchwork-atlanta-for-content-creators" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2160-patchwork-atlanta-for-content-creators" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2160-patc</span><span class="invisible">hwork-atlanta-for-content-creators</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/724978829815648256?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/LAKRnaNuii"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/724978829815648256?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:09 AM - 26 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/724978829815648256"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="31">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>31 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">31</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="724737783382691840" id="stream-item-tweet-724737783382691840" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="724737783382691840"
+data-item-id="724737783382691840"
+data-permalink-path="/github/status/724737783382691840"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;4:12 PM - 25 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/724737783382691840&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/724737783382691840" class="tweet-timestamp js-permalink js-nav js-tooltip" title="4:12 PM - 25 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461625927" data-time-ms="1461625927000" data-long-form="true">Apr 25</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Registration is open! Play, sponsor, or donate to our Dodgeball Tournament and support San Francisco nonprofits:<a href="https://t.co/AvGKYsKzKt" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2159-2016-dodgeball-tournament-play-sponsor-donate" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2159-2016-dodgeball-tournament-play-sponsor-donate" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2159-2016</span><span class="invisible">-dodgeball-tournament-play-sponsor-donate</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/724737783382691840?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/AvGKYsKzKt"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/724737783382691840?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>4:12 PM - 25 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/724737783382691840"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="67">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>67 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723557661820751872" id="stream-item-tweet-723557661820751872" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="723557661820751872"
+data-item-id="723557661820751872"
+data-permalink-path="/github/status/723557661820751872"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;10:02 AM - 22 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723557661820751872&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723557661820751872" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:02 AM - 22 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461344564" data-time-ms="1461344564000" data-long-form="true">Apr 22</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">You can now subscribe to additional webhook events<a href="https://t.co/yxbY3BIsfk" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2156-expanded-webhook-events" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2156-expanded-webhook-events" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2156-expa</span><span class="invisible">nded-webhook-events</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/723557661820751872?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/yxbY3BIsfk"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/723557661820751872?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:02 AM - 22 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/723557661820751872"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="66">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>66 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="105">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>105 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">66</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">66</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">105</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">105</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723413639558885376" id="stream-item-tweet-723413639558885376" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="723413639558885376"
+data-item-id="723413639558885376"
+data-permalink-path="/github/status/723413639558885376"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:30 AM - 22 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723413639558885376&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723413639558885376" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:30 AM - 22 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461310226" data-time-ms="1461310226000" data-long-form="true">Apr 22</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Satellite is 2 weeks away! Get your ticket and hear from engineers at Heroku, Facebook, Spotify and more: <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="22">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>22 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="34">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>34 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">22</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">22</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723217327274242049" id="stream-item-tweet-723217327274242049" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="723217327274242049"
+data-item-id="723217327274242049"
+data-permalink-path="/github/status/723217327274242049"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:30 AM - 21 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723217327274242049&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723217327274242049" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:30 AM - 21 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461263422" data-time-ms="1461263422000" data-long-form="true">Apr 21</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Preview GitHub Pages metadata locally<a href="https://t.co/636j3yIPSX" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2154-preview-github-pages-metadata-locally" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2154-preview-github-pages-metadata-locally" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2154-prev</span><span class="invisible">iew-github-pages-metadata-locally</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/723217327274242049?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/636j3yIPSX"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/723217327274242049?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:30 AM - 21 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/723217327274242049"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="44">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>44 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="69">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>69 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">44</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">69</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">69</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="723058774936711172" id="stream-item-tweet-723058774936711172" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="723058774936711172"
+data-item-id="723058774936711172"
+data-permalink-path="/github/status/723058774936711172"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="KPN Zalando Tesco UBS"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;1:00 AM - 21 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/723058774936711172&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/723058774936711172" class="tweet-timestamp js-permalink js-nav js-tooltip" title="1:00 AM - 21 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461225620" data-time-ms="1461225620000" data-long-form="true">Apr 21</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">At Satellite, hear how companies like <a href="/KPN" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="19103718" ><s>@</s><b>KPN</b></a>, <a href="/Zalando" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="59900894" ><s>@</s><b>Zalando</b></a>, <a href="/Tesco" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="271986064" ><s>@</s><b>Tesco</b></a>, and <a href="/UBS" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="38237581" ><s>@</s><b>UBS</b></a> are using software to change how they work:<a href="https://t.co/HCdOteglYo" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2155-join-us-at-github-satellite-to-hear-how-top-european-companies-build-software" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2155-join-us-at-github-satellite-to-hear-how-top-european-companies-build-software" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2155-join</span><span class="invisible">-us-at-github-satellite-to-hear-how-top-european-companies-build-software</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/723058774936711172?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/HCdOteglYo"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/723058774936711172?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>1:00 AM - 21 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/723058774936711172"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="33">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>33 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="722466967161028610" id="stream-item-tweet-722466967161028610" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="722466967161028610"
+data-item-id="722466967161028610"
+data-permalink-path="/github/status/722466967161028610"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:48 AM - 19 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/722466967161028610&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/722466967161028610" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:48 AM - 19 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461084522" data-time-ms="1461084522000" data-long-form="true">Apr 19</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Our next Patchwork will be in St. Louis on April 26:<a href="https://t.co/ZQIsiYMPiC" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2153-patchwork-st-louis" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2153-patchwork-st-louis" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2153-patc</span><span class="invisible">hwork-st-louis</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/722466967161028610?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/ZQIsiYMPiC"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/722466967161028610?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:48 AM - 19 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/722466967161028610"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="20">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>20 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="26">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>26 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">20</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">26</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="722326422090420224" id="stream-item-tweet-722326422090420224" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="722326422090420224"
+data-item-id="722326422090420224"
+data-permalink-path="/github/status/722326422090420224"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:30 AM - 19 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/722326422090420224&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/722326422090420224" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:30 AM - 19 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461051013" data-time-ms="1461051013000" data-long-form="true">Apr 19</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Satellite is only 3 weeks away! Get your ticket now and join us in Amsterdam:  <a href="https://t.co/AAAKlmQ5ST" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="23">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>23 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="36">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>36 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">23</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">23</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">36</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">36</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="722157438015680512" id="stream-item-tweet-722157438015680512" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="722157438015680512"
+data-item-id="722157438015680512"
+data-permalink-path="/github/status/722157438015680512"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/722157438015680512" class="tweet-timestamp js-permalink js-nav js-tooltip" title="1:18 PM - 18 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1461010724" data-time-ms="1461010724000" data-long-form="true">Apr 18</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">The annual GitHub Dodgeball Tournament returns on June 5th. Stay tuned for details!<a href="https://t.co/TRToRi9EQw" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/TRToRi9EQw</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-quadPhoto">
+    <div class="AdaptiveMedia-threeQuartersWidthPhoto">
+      <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXNfVAAI9AyC.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXNfVAAI9AyC.jpg" alt=""
+      style="height: 100%; left: -94px;"
+>
+</div>
+
+
+    </div>
+  <div class="AdaptiveMedia-thirdHeightPhotoContainer">
+      <div class="AdaptiveMedia-thirdHeightPhoto">
+        <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXOMUsAARUet.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXOMUsAARUet.jpg" alt=""
+      style="height: 100%; left: -31px;"
+>
+</div>
+
+
+      </div>      
+      <div class="AdaptiveMedia-thirdHeightPhoto">
+        <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXOMUYAAIkyH.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXOMUYAAIkyH.jpg" alt=""
+      style="height: 100%; left: -31px;"
+>
+</div>
+
+
+      </div>      
+      <div class="AdaptiveMedia-thirdHeightPhoto">
+        <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CgWeXNvVAAADso7.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CgWeXNvVAAADso7.jpg" alt=""
+      style="height: 100%; left: -31px;"
+>
+</div>
+
+
+      </div>      
+  </div>
+</div>
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>1:18 PM - 18 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/722157438015680512"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="64">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>64 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="209">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>209 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">64</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">64</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">209</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">209</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="720901243703468032" id="stream-item-tweet-720901243703468032" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="720901243703468032"
+data-item-id="720901243703468032"
+data-permalink-path="/github/status/720901243703468032"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;2:07 AM - 15 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/720901243703468032&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/720901243703468032" class="tweet-timestamp js-permalink js-nav js-tooltip" title="2:07 AM - 15 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460711224" data-time-ms="1460711224000" data-long-form="true">Apr 15</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Check out the GitHub Satellite speaker lineup and grab your tickets while they last:<a href="https://t.co/qSJxFTxJt5" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2152-github-satellite-schedule-announced" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2152-github-satellite-schedule-announced" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2152-gith</span><span class="invisible">ub-satellite-schedule-announced</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/720901243703468032?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/qSJxFTxJt5"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/720901243703468032?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>2:07 AM - 15 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/720901243703468032"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="38">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>38 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="43">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>43 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">43</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="720664290655469569" id="stream-item-tweet-720664290655469569" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="720664290655469569"
+data-item-id="720664290655469569"
+data-permalink-path="/github/status/720664290655469569"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;10:25 AM - 14 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/720664290655469569&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/720664290655469569" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:25 AM - 14 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460654730" data-time-ms="1460654730000" data-long-form="true">Apr 14</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">CodeConf LA call for proposals deadline extended to April 29. Have something to say about open source? Apply Now:<a href="https://t.co/SIlqKpLumO" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2149-call-for-proposals-codeconf-la-june-27-29-2016" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2149-call-for-proposals-codeconf-la-june-27-29-2016" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2149-call</span><span class="invisible">-for-proposals-codeconf-la-june-27-29-2016</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/720664290655469569?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/SIlqKpLumO"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/720664290655469569?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:25 AM - 14 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/720664290655469569"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="63">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>63 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="80">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>80 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">63</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">63</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="720294383233306625" id="stream-item-tweet-720294383233306625" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="720294383233306625"
+data-item-id="720294383233306625"
+data-permalink-path="/github/status/720294383233306625"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:55 AM - 13 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/720294383233306625&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/720294383233306625" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:55 AM - 13 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460566538" data-time-ms="1460566538000" data-long-form="true">Apr 13</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Quench your thirst with the new GitHub Water Bottle. Now available in the GitHub Shop.<a href="https://t.co/eqze7dLQlX" rel="nofollow" dir="ltr" data-expanded-url="http://shop.github.com/products/water-bottle" class="twitter-timeline-link u-hidden" target="_blank" title="http://shop.github.com/products/water-bottle" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">shop.github.com/products/water</span><span class="invisible">-bottle</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/720294383233306625?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/eqze7dLQlX"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/720294383233306625?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:55 AM - 13 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/720294383233306625"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="136">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>136 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">136</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">136</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="719972773641084928" id="stream-item-tweet-719972773641084928" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="719972773641084928"
+data-item-id="719972773641084928"
+data-permalink-path="/github/status/719972773641084928"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="photonstorm"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:37 PM - 12 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/719972773641084928&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/719972773641084928" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:37 PM - 12 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460489860" data-time-ms="1460489860000" data-long-form="true">Apr 12</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">“Phaser was a weekend creation—utterly unplanned, but utterly wonderful.” Meet <a href="/photonstorm" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="21861033" ><s>@</s><b>photonstorm</b></a> in our new dev profile:<a href="https://t.co/SS3uSQ8wgQ" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2148-meet-richard-davey-creator-of-phaser?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-richard-davey" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2148-meet-richard-davey-creator-of-phaser?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-richard-davey" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2148-meet</span><span class="invisible">-richard-davey-creator-of-phaser?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-richard-davey</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/719972773641084928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/SS3uSQ8wgQ"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/719972773641084928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:37 PM - 12 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/719972773641084928"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="80">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>80 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="184">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>184 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">80</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="719528183859703808" id="stream-item-tweet-719528183859703808" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="719528183859703808"
+data-item-id="719528183859703808"
+data-permalink-path="/github/status/719528183859703808"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;7:11 AM - 11 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/719528183859703808&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/719528183859703808" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:11 AM - 11 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1460383861" data-time-ms="1460383861000" data-long-form="true">Apr 11</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Patchwork comes to Reading, UK on April 19. Will you join us?<a href="https://t.co/40C3ytJYDA" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2147-patchwork-reading-uk" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2147-patchwork-reading-uk" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2147-patc</span><span class="invisible">hwork-reading-uk</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/719528183859703808?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/40C3ytJYDA"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/719528183859703808?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>7:11 AM - 11 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/719528183859703808"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="25">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>25 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="25">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>25 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">25</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717543492818481156" id="stream-item-tweet-717543492818481156" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="717543492818481156"
+data-item-id="717543492818481156"
+data-permalink-path="/github/status/717543492818481156"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717543492818481156" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:44 PM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459910674" data-time-ms="1459910674000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">That&#39;s a wrap! Thanks everyone for another great <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a>! We&#39;ll see you in 2017.<a href="https://t.co/K1zMWk4ZN1" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/K1zMWk4ZN1</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      is-square
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-singlePhoto">
+    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CfU6ARWW8AAASlA.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CfU6ARWW8AAASlA.jpg" alt=""
+      style="width: 100%; top: -0px;"
+>
+</div>
+
+
+</div>
+
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>7:44 PM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717543492818481156"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="48">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>48 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="201">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>201 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">201</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">201</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717418093547556865" id="stream-item-tweet-717418093547556865" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717418093547556865"
+data-item-id="717418093547556865"
+data-permalink-path="/github/status/717418093547556865"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="fredhutch"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:26 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717418093547556865&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717418093547556865" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:26 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459880777" data-time-ms="1459880777000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">For the team at <a href="/fredhutch" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="16645335" ><s>@</s><b>fredhutch</b></a>, open source is the key to unlocking cancer. Watch the latest OctoTale:<a href="https://t.co/YTTs4lxf4O" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2145-from-the-octotales-video-series-advancing-cancer-research-through-open-source" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2145-from-the-octotales-video-series-advancing-cancer-research-through-open-source" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2145-from</span><span class="invisible">-the-octotales-video-series-advancing-cancer-research-through-open-source</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/717418093547556865?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/YTTs4lxf4O"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717418093547556865?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:26 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717418093547556865"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="47">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>47 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="76">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>76 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">47</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">47</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">76</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">76</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717415340733513728" id="stream-item-tweet-717415340733513728" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717415340733513728"
+data-item-id="717415340733513728"
+data-permalink-path="/github/status/717415340733513728"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:15 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717415340733513728&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717415340733513728" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:15 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459880120" data-time-ms="1459880120000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">You can now verify GPG signed commits and tags!<a href="https://t.co/JM5esTwcOn" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2144-gpg-signature-verification" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2144-gpg-signature-verification" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2144-gpg-</span><span class="invisible">signature-verification</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/717415340733513728?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/JM5esTwcOn"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717415340733513728?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:15 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717415340733513728"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="679">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>679 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="678">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>678 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">679</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">679</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">678</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">678</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717400932531773440" id="stream-item-tweet-717400932531773440" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="717400932531773440"
+data-item-id="717400932531773440"
+data-permalink-path="/github/status/717400932531773440"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="emmajanehw"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717400932531773440" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:18 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459876685" data-time-ms="1459876685000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Kicking off our afternoon <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a> sessions with <a href="/emmajanehw" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="14336120" ><s>@</s><b>emmajanehw</b></a>. Check out the live stream: <a href="https://t.co/nJTSI585zd" rel="nofollow" dir="ltr" data-expanded-url="https://live-stream.github.com/" class="twitter-timeline-link" target="_blank" title="https://live-stream.github.com/" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">live-stream.github.com</span><span class="invisible">/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a><a href="https://t.co/uVrjZgwVpO" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/uVrjZgwVpO</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      is-square
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-singlePhoto">
+    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CfS4WMWXEAEpOQG.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CfS4WMWXEAEpOQG.jpg" alt=""
+      style="width: 100%; top: -0px;"
+>
+</div>
+
+
+</div>
+
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>10:18 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717400932531773440"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="35">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>35 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="41">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>41 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">35</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">35</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">41</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">41</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717337520900452353" id="stream-item-tweet-717337520900452353" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717337520900452353"
+data-item-id="717337520900452353"
+data-permalink-path="/GitHubEng/status/717337520900452353"
+
+
+
+
+
+
+    data-retweet-id="717395312747237376"
+     data-retweeter="github"
+
+
+  data-screen-name="GitHubEng" data-name="GitHub Engineering" data-user-id="3131295561"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;6:06 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/GitHubEng/status/717337520900452353&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+          <div class="tweet-context with-icn
+    
+    ">
+
+      <span class="Icon Icon--small Icon--retweeted"></span>
+
+
+
+
+
+            <span class="js-retweet-text"><a class="pretty-link js-user-profile-link" href="/github" data-user-id="13334762"><b>GitHub Retweeted</b></a></span>
+
+
+      
+
+
+
+    </div>
+
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/GitHubEng" data-user-id="3131295561">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/593061696039706627/uzIQ4lJF_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub Engineering</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>GitHubEng</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/GitHubEng/status/717337520900452353" class="tweet-timestamp js-permalink js-nav js-tooltip" title="6:06 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459861567" data-time-ms="1459861567000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Introducing DGit by Patrick Reynolds<a href="https://t.co/gqxJJO34jU" rel="nofollow" dir="ltr" data-expanded-url="http://githubengineering.com/introducing-dgit/" class="twitter-timeline-link u-hidden" target="_blank" title="http://githubengineering.com/introducing-dgit/" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">githubengineering.com/introducing-dg</span><span class="invisible">it/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/717337520900452353?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/gqxJJO34jU"
+  data-publisher-id="3131295561"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717337520900452353?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>6:06 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/GitHubEng/status/717337520900452353"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="215">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>215 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="184">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>184 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">215</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">184</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717375394400362497" id="stream-item-tweet-717375394400362497" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="717375394400362497"
+data-item-id="717375394400362497"
+data-permalink-path="/github/status/717375394400362497"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="p_reynolds"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717375394400362497" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:36 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459870596" data-time-ms="1459870596000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Thanks <a href="/p_reynolds" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="14448514" ><s>@</s><b>p_reynolds</b></a> for talking us through the debut of DGit at <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a>! Get more details: <a href="https://t.co/14zcUwx3zT" rel="nofollow" dir="ltr" data-expanded-url="http://githubengineering.com/introducing-dgit/" class="twitter-timeline-link" target="_blank" title="http://githubengineering.com/introducing-dgit/" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">githubengineering.com/introducing-dg</span><span class="invisible">it/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a><a href="https://t.co/x5pObaZVbu" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/x5pObaZVbu</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      
+      
+      is-square
+      
+      
+      "
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-singlePhoto">
+    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
+  data-image-url="https://pbs.twimg.com/media/CfShHrAUAAAvu2w.jpg"
+  
+  
+  data-element-context="platform_photo_card">
+  <img data-aria-label-part src="https://pbs.twimg.com/media/CfShHrAUAAAvu2w.jpg" alt=""
+      style="width: 100%; top: -0px;"
+>
+</div>
+
+
+</div>
+
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>8:36 AM - 5 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717375394400362497"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="60">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>60 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="96">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>96 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">96</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">96</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717359961781743619" id="stream-item-tweet-717359961781743619" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="717359961781743619"
+data-item-id="717359961781743619"
+data-permalink-path="/github/status/717359961781743619"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="gregkh"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;7:35 AM - 5 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717359961781743619&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717359961781743619" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:35 AM - 5 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459866917" data-time-ms="1459866917000" data-long-form="true">Apr 5</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Kicking off <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a> with a talk from <a href="/gregkh" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="14768955" ><s>@</s><b>gregkh</b></a> of the Linux Foundation. Tune in to the live stream now: <a href="https://t.co/nJTSI585zd" rel="nofollow" dir="ltr" data-expanded-url="https://live-stream.github.com/" class="twitter-timeline-link" target="_blank" title="https://live-stream.github.com/" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">live-stream.github.com</span><span class="invisible">/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="32">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>32 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="32">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>32 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">32</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717206379853955073" id="stream-item-tweet-717206379853955073" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       
+"
+      
+data-tweet-id="717206379853955073"
+data-item-id="717206379853955073"
+data-permalink-path="/github/status/717206379853955073"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:25 PM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717206379853955073&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717206379853955073" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:25 PM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459830300" data-time-ms="1459830300000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Hear from Heroku, Facebook and more at GitHub Satellite: <a href="https://t.co/AAAKln7Hht" rel="nofollow" dir="ltr" data-expanded-url="http://www.ticketbase.com/events/github-satellite" class="twitter-timeline-link" target="_blank" title="http://www.ticketbase.com/events/github-satellite" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">ticketbase.com/events/github-</span><span class="invisible">satellite</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="38">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>38 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="53">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>53 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">38</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">53</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717152191627337729" id="stream-item-tweet-717152191627337729" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717152191627337729"
+data-item-id="717152191627337729"
+data-permalink-path="/github/status/717152191627337729"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;5:49 PM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717152191627337729&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717152191627337729" class="tweet-timestamp js-permalink js-nav js-tooltip" title="5:49 PM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459817381" data-time-ms="1459817381000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Organizations can now block abusive users from public repositories<a href="https://t.co/p59wkq1uhX" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2146-organizations-can-now-block-abusive-users" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2146-organizations-can-now-block-abusive-users" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2146-orga</span><span class="invisible">nizations-can-now-block-abusive-users</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/717152191627337729?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/p59wkq1uhX"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717152191627337729?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>5:49 PM - 4 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717152191627337729"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="376">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>376 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="492">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>492 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">376</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">376</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">492</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">492</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="717023229701971968" id="stream-item-tweet-717023229701971968" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="717023229701971968"
+data-item-id="717023229701971968"
+data-permalink-path="/github/status/717023229701971968"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:17 AM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/717023229701971968&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/717023229701971968" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:17 AM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459786634" data-time-ms="1459786634000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">In or around Philadelphia next week? Join us for a Patchwork on April 12:<a href="https://t.co/Z5wu0J8QdI" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2143-patchwork-philadelphia" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2143-patchwork-philadelphia" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2143-patc</span><span class="invisible">hwork-philadelphia</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/717023229701971968?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/Z5wu0J8QdI"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/717023229701971968?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:17 AM - 4 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/717023229701971968"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="18">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>18 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="30">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>30 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">18</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">18</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">30</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">30</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="716989838390636544" id="stream-item-tweet-716989838390636544" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="716989838390636544"
+data-item-id="716989838390636544"
+data-permalink-path="/GitHubEducation/status/716989838390636544"
+
+
+
+
+
+
+    data-retweet-id="716990281229402116"
+     data-retweeter="github"
+
+
+  data-screen-name="GitHubEducation" data-name="GitHub Education" data-user-id="1943578656"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;7:04 AM - 4 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/GitHubEducation/status/716989838390636544&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+          <div class="tweet-context with-icn
+    
+    ">
+
+      <span class="Icon Icon--small Icon--retweeted"></span>
+
+
+
+
+
+            <span class="js-retweet-text"><a class="pretty-link js-user-profile-link" href="/github" data-user-id="13334762"><b>GitHub Retweeted</b></a></span>
+
+
+      
+
+
+
+    </div>
+
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/GitHubEducation" data-user-id="1943578656">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/378800000561692042/a26a14bdfa11b045632e66b05369bc48_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub Education</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>GitHubEducation</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/GitHubEducation/status/716989838390636544" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:04 AM - 4 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459778673" data-time-ms="1459778673000" data-long-form="true">Apr 4</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Supporting the student hacker community:<a href="https://t.co/8BARXftyfn" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2140-supporting-the-student-hacker-community" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2140-supporting-the-student-hacker-community" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2140-supp</span><span class="invisible">orting-the-student-hacker-community</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/716989838390636544?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/8BARXftyfn"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/716989838390636544?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>7:04 AM - 4 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/GitHubEducation/status/716989838390636544"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="86">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>86 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="142">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>142 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">86</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">86</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">142</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">142</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715969911462428672" id="stream-item-tweet-715969911462428672" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715969911462428672"
+data-item-id="715969911462428672"
+data-permalink-path="/github/status/715969911462428672"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:31 AM - 1 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715969911462428672&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715969911462428672" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:31 AM - 1 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459535503" data-time-ms="1459535503000" data-long-form="true">Apr 1</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Squash your Pull Requests on merge<a href="https://t.co/dj1eGecO9h" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2141-squash-your-commits" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2141-squash-your-commits" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2141-squa</span><span class="invisible">sh-your-commits</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/715969911462428672?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/dj1eGecO9h"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715969911462428672?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:31 AM - 1 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715969911462428672"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1045">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>1,045 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1035">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>1,035 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1K</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715939189964062725" id="stream-item-tweet-715939189964062725" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715939189964062725"
+data-item-id="715939189964062725"
+data-permalink-path="/github/status/715939189964062725"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:29 AM - 1 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715939189964062725&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715939189964062725" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:29 AM - 1 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459528179" data-time-ms="1459528179000" data-long-form="true">Apr 1</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GitHub Pages will standardize on a single Markdown engine on May 1st. Here&#39;s why:<a href="https://t.co/pwMdAdEWg5" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2136-a-look-behind-our-decision-to-standardize-on-a-single-markdown-engine-for-github-pages" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2136-a-look-behind-our-decision-to-standardize-on-a-single-markdown-engine-for-github-pages" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2136-a-lo</span><span class="invisible">ok-behind-our-decision-to-standardize-on-a-single-markdown-engine-for-github-pages</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/715939189964062725?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/pwMdAdEWg5"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715939189964062725?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:29 AM - 1 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715939189964062725"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="168">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>168 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="180">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>180 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">168</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">168</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">180</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715810869603667970" id="stream-item-tweet-715810869603667970" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715810869603667970"
+data-item-id="715810869603667970"
+data-permalink-path="/github/status/715810869603667970"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;12:59 AM - 1 Apr 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715810869603667970&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715810869603667970" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:59 AM - 1 Apr 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459497585" data-time-ms="1459497585000" data-long-form="true">Apr 1</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Check out speakers from Facebook, Heroku and Women Who Code at GitHub Satellite:<a href="https://t.co/tWB9tgUtko" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2142-github-satellite-sessions-preview" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2142-github-satellite-sessions-preview" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2142-gith</span><span class="invisible">ub-satellite-sessions-preview</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/715810869603667970?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/tWB9tgUtko"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715810869603667970?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:59 AM - 1 Apr 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715810869603667970"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="60">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>60 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="99">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>99 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">60</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">99</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">99</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715287568850366465" id="stream-item-tweet-715287568850366465" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715287568850366465"
+data-item-id="715287568850366465"
+data-permalink-path="/github/status/715287568850366465"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;2:20 PM - 30 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715287568850366465&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715287568850366465" class="tweet-timestamp js-permalink js-nav js-tooltip" title="2:20 PM - 30 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459372820" data-time-ms="1459372820000" data-long-form="true">Mar 30</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">We’re just days away from <a href="/hashtag/gitmerge?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>gitmerge</b></a> on April 5 in NYC. Check out what we have in store:<a href="https://t.co/Wb6mlL8C2f" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2138-git-merge-is-sold-out-see-what-s-on-tap?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-sold-out-20160330" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2138-git-merge-is-sold-out-see-what-s-on-tap?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-sold-out-20160330" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2138-git-</span><span class="invisible">merge-is-sold-out-see-what-s-on-tap?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-sold-out-20160330</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/715287568850366465?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/Wb6mlL8C2f"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715287568850366465?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>2:20 PM - 30 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715287568850366465"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="34">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>34 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="48">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>48 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">34</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">48</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="715217314040438784" id="stream-item-tweet-715217314040438784" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="715217314040438784"
+data-item-id="715217314040438784"
+data-permalink-path="/github/status/715217314040438784"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;9:41 AM - 30 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/715217314040438784&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/715217314040438784" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:41 AM - 30 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459356070" data-time-ms="1459356070000" data-long-form="true">Mar 30</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Improvements to protected branches: restrict push access and merge out-of-date pull requests<a href="https://t.co/sS3Pa5HIx2" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2137-protected-branches-improvements" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2137-protected-branches-improvements" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2137-prot</span><span class="invisible">ected-branches-improvements</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary"
+  data-src="/i/cards/tfw/v1/715217314040438784?cardname=summary&amp;earned=true&amp;lang=en"
+  data-card-name="summary"
+  data-card-url="https://t.co/sS3Pa5HIx2"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/715217314040438784?cardname=summary&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>9:41 AM - 30 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/715217314040438784"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="155">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>155 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="170">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>170 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">155</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">155</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">170</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">170</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714947571400060928" id="stream-item-tweet-714947571400060928" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714947571400060928"
+data-item-id="714947571400060928"
+data-permalink-path="/github/status/714947571400060928"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;3:49 PM - 29 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714947571400060928&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714947571400060928" class="tweet-timestamp js-permalink js-nav js-tooltip" title="3:49 PM - 29 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459291758" data-time-ms="1459291758000" data-long-form="true">Mar 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--16px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Git Merge is nearly sold out! There are just a handful of tickets left, so get yours while they last:<a href="https://t.co/Kailn2ayML" rel="nofollow" dir="ltr" data-expanded-url="http://git-merge.com?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-nearly-sold-out-20160329" class="twitter-timeline-link u-hidden" target="_blank" title="http://git-merge.com?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-nearly-sold-out-20160329" ><span class="tco-ellipsis"></span><span class="invisible">http://git-merge.com?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=www-git-merge-nearly-sold-out-20160329</span><span class="js-display-url">git-merge.com/?utm_source=tw</span><span class="invisible"></span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714947571400060928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/Kailn2ayML"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714947571400060928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>3:49 PM - 29 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714947571400060928"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="33">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>33 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="73">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>73 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">33</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">73</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">73</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714890877290700800" id="stream-item-tweet-714890877290700800" data-item-type="tweet">
+      
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards  has-content
+"
+      
+data-tweet-id="714890877290700800"
+data-item-id="714890877290700800"
+data-permalink-path="/github/status/714890877290700800"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714890877290700800" class="tweet-timestamp js-permalink js-nav js-tooltip" title="12:04 PM - 29 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459278241" data-time-ms="1459278241000" data-long-form="true">Mar 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Saved replies have launched. Now you can save your most commonly used replies. <a href="https://t.co/BHLdUPdE9i" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2135-saved-replies" class="twitter-timeline-link" target="_blank" title="https://github.com/blog/2135-saved-replies" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2135-save</span><span class="invisible">d-replies</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a><a href="https://t.co/e8IYnq5rOP" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/e8IYnq5rOP</a></p>
+</div>
+
+
+
+
+      
+            <div class="AdaptiveMedia
+      allow-expansion
+      
+      is-square
+      is-generic-video
+      
+      has-autoplayable-media"
+    >
+    <div class="AdaptiveMedia-container
+        js-adaptive-media-container
+        "
+      >
+        <div class="AdaptiveMedia-video">
+  <div class="AdaptiveMedia-videoContainer">
+      <div class="PlayableMedia PlayableMedia--gif">
+
+  <div
+    class="PlayableMedia-player
+      
+      
+      "
+    data-playable-media-url=""
+    style="padding-bottom: 50.66666666666667%; background-image:url('https://pbs.twimg.com/tweet_video_thumb/CevJOxzW4AAzfUc.jpg')">
+  </div>
+
+  
+  
+</div>
+
+  </div>
+</div>
+
+    </div>
+  </div>
+
+
+
+      
+      
+  <div class="expanded-content js-tweet-details-dropdown">
+    <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>12:04 PM - 29 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714890877290700800"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="577">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>577 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="695">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>695 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">577</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">695</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">695</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714878577611644928" id="stream-item-tweet-714878577611644928" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714878577611644928"
+data-item-id="714878577611644928"
+data-permalink-path="/github/status/714878577611644928"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:15 AM - 29 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714878577611644928&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714878577611644928" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:15 AM - 29 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459275309" data-time-ms="1459275309000" data-long-form="true">Mar 29</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Meet Sean Marcia, developer, bee saver, and founder of Ruby for Good:<a href="https://t.co/is3LX6jdTx" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2133-meet-sean-marcia-founder-of-ruby-for-good?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-sean-marcia" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2133-meet-sean-marcia-founder-of-ruby-for-good?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-sean-marcia" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2133-meet</span><span class="invisible">-sean-marcia-founder-of-ruby-for-good?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=developer-profile-sean-marcia</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714878577611644928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/is3LX6jdTx"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714878577611644928?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:15 AM - 29 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714878577611644928"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="67">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>67 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="111">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>111 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">67</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">111</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">111</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714585691863142400" id="stream-item-tweet-714585691863142400" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714585691863142400"
+data-item-id="714585691863142400"
+data-permalink-path="/github/status/714585691863142400"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;3:51 PM - 28 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714585691863142400&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714585691863142400" class="tweet-timestamp js-permalink js-nav js-tooltip" title="3:51 PM - 28 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459205479" data-time-ms="1459205479000" data-long-form="true">Mar 28</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Git 2.8 has been released and we&#39;d like to share some highlights with you:<a href="https://t.co/kAgMCsZjzU" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2131-git-2-8-has-been-released?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=git-release-2.7-20160328" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2131-git-2-8-has-been-released?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=git-release-2.7-20160328" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2131-git-</span><span class="invisible">2-8-has-been-released?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=git-release-2.7-20160328</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714585691863142400?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/kAgMCsZjzU"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714585691863142400?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>3:51 PM - 28 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714585691863142400"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="719">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>719 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="691">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>691 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">719</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">719</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">691</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">691</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+      <li class="js-stream-item stream-item stream-item expanding-stream-item
+" data-item-id="714522458494140416" id="stream-item-tweet-714522458494140416" data-item-type="tweet">
+    <ol role="presentation" class="expanded-conversation expansion-container js-expansion-container js-navigable-stream">
+  <li role="presentation" class="original-tweet-container">
+    
+
+
+  
+
+  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
+       original-tweet js-original-tweet
+      
+       has-cards cards-forward
+"
+      
+data-tweet-id="714522458494140416"
+data-item-id="714522458494140416"
+data-permalink-path="/github/status/714522458494140416"
+
+
+
+
+
+
+
+
+  data-screen-name="github" data-name="GitHub" data-user-id="13334762"
+  data-you-follow="false"
+  data-follows-you="false"
+  data-you-block="false"
+ data-mentions="AtomEditor"
+
+
+
+
+
+
+
+
+data-disclosure-type=""
+
+
+
+ data-card2-type="summary_large_image"
+ data-has-cards="true"
+
+
+
+
+
+
+
+
+
+
+
+
+ data-expanded-footer="&lt;div class=&quot;js-tweet-details-fixer tweet-details-fixer&quot;&gt;&#10;&#10;  &lt;div class=&quot;js-machine-translated-tweet-container&quot;&gt;&lt;/div&gt;&#10;  &lt;div class=&quot;js-tweet-stats-container tweet-stats-container &quot;&gt;&#10;  &lt;/div&gt;&#10;&#10;  &lt;div class=&quot;client-and-actions&quot;&gt;&#10;  &lt;span class=&quot;metadata&quot;&gt;&#10;    &lt;span&gt;11:40 AM - 28 Mar 2016&lt;/span&gt;&#10;       &amp;middot; &lt;a class=&quot;permalink-link js-permalink js-nav&quot; href=&quot;/github/status/714522458494140416&quot;  tabindex=&quot;-1&quot;&gt;Details&lt;/a&gt;&#10;  &lt;/span&gt;&#10;&lt;/div&gt;&#10;&#10;&#10;&lt;/div&gt;&#10;"
+
+    >
+
+
+    <div class="context">
+      
+      
+    </div>
+
+    <div class="content">
+      
+
+      
+      <div class="stream-item-header">
+          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/github" data-user-id="13334762">
+    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/616309728688238592/pBeeJQDQ_bigger.png" alt="">
+    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>GitHub</strong>
+    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>github</b></span>
+    
+  </a>
+
+        <small class="time">
+  <a href="/github/status/714522458494140416" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:40 AM - 28 Mar 2016" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1459190403" data-time-ms="1459190403000" data-long-form="true">Mar 28</span></a>
+</small>
+
+          
+          
+      </div>
+
+      
+        <div class="js-tweet-text-container">
+  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Atom has reached one million active users—all thanks to <a href="/AtomEditor" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="2339397540" ><s>@</s><b>AtomEditor</b></a> supporters and contributors.<a href="https://t.co/CocbtHscmm" rel="nofollow" dir="ltr" data-expanded-url="https://github.com/blog/2132-atom-reaches-one-million-active-users" class="twitter-timeline-link u-hidden" target="_blank" title="https://github.com/blog/2132-atom-reaches-one-million-active-users" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">github.com/blog/2132-atom</span><span class="invisible">-reaches-one-million-active-users</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
+</div>
+
+
+
+
+      
+        
+
+      
+          <div class="card2 js-media-container
+    "
+    data-card2-name="summary_large_image"
+  >
+    <div class="js-macaw-cards-iframe-container initial-card-height card-type-summary_large_image"
+  data-src="/i/cards/tfw/v1/714522458494140416?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-card-name="summary_large_image"
+  data-card-url="https://t.co/CocbtHscmm"
+  data-publisher-id="13334762"
+  data-creator-id=""
+  data-amplify-content-id=""
+  data-amplify-playlist-url=""
+  data-full-card-iframe-url="/i/cards/tfw/v1/714522458494140416?cardname=summary_large_image&amp;earned=true&amp;lang=en"
+  data-has-autoplayable-media="false">
+</div>
+
+</div>
+
+
+  <div class="expanded-content js-tweet-details-dropdown">
+    
+      <div class="js-tweet-details-fixer tweet-details-fixer">
+
+  <div class="js-machine-translated-tweet-container"></div>
+  <div class="js-tweet-stats-container tweet-stats-container ">
+  </div>
+
+  <div class="client-and-actions">
+  <span class="metadata">
+    <span>11:40 AM - 28 Mar 2016</span>
+       &middot; <a class="permalink-link js-permalink js-nav" href="/github/status/714522458494140416"  tabindex="-1">Details</a>
+  </span>
+</div>
+
+
+</div>
+
+  </div>
+
+
+      
+      <div class="stream-item-footer">
+  
+
+  
+        <div class="ProfileTweet-actionCountList u-hiddenVisually">
+    
+    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
+    <span class="ProfileTweet-action--retweet u-hiddenVisually">
+      
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="314">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>314 retweets</span>
+      </span>
+    </span>
+    <span class="ProfileTweet-action--favorite u-hiddenVisually">
+      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="552">
+        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>552 likes</span>
+      </span>
+    </span>
+  </div>
+
+    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
+      <div class="ProfileTweet-action ProfileTweet-action--reply">
+  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
+    data-modal="ProfileTweet-reply"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Reply">
+      <span class="Icon Icon--reply"></span>
+      <span class="u-hiddenVisually">Reply</span>
+    </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
+  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
+    
+    data-modal="ProfileTweet-retweet"
+    type="button">
+    <div class="IconContainer js-tooltip" title="Retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweet</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">314</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
+    <div class="IconContainer js-tooltip" title="Undo retweet">
+      <span class="Icon Icon--retweet"></span>
+      <span class="u-hiddenVisually">Retweeted</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">314</span>
+        </span>
+      </div>
+  </button>
+</div>
+      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
+  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Like</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">552</span>
+        </span>
+      </div>
+  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
+    <div class="IconContainer js-tooltip" title="Undo like">
+      <div class="HeartAnimationContainer">
+        <div class="HeartAnimation"></div>
+      </div>
+      <span class="u-hiddenVisually">Liked</span>
+    </div>
+      <div class="IconTextContainer">
+        <span class="ProfileTweet-actionCount">
+          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">552</span>
+        </span>
+      </div>
+  </button>
+</div>
+      
+
+        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
+    <div class="dropdown">
+  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
+      <div class="IconContainer js-tooltip" title="More">
+        <span class="Icon Icon--dots"></span>
+        <span class="u-hiddenVisually">More</span>
+      </div>
+  </button>
+  <div class="dropdown-menu">
+  <div class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <ul>
+    
+      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
+        <button type="button" class="dropdown-link">Copy link to Tweet</button>
+      </li>
+      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
+        <button type="button" class="dropdown-link">Embed Tweet</button>
+      </li>
+        
+  </ul>
+</div>
+
+</div>
+
+  </div>
+
+    </div>
+
+</div>
+  
+
+
+
+      
+      
+
+    </div>
+  </div>
+
+
+  </li>
+</ol>
+
+</li>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+        </ol>
+        <div class="stream-footer ">
+  <div class='timeline-end has-items has-more-items'>
+    <div class="stream-end">
+  <div class="stream-end-inner">
+      <span class="Icon Icon--large Icon--logo"></span>
+
+    <p class="empty-text">
+        @github hasn&#39;t tweeted yet.
+
+    </p>
+
+          <p><button type='button' class='btn-link back-to-top hidden'>Back to top &uarr;</button></p>
+
+  </div>
+</div>
+
+    <div class="stream-loading">
+  <div class="stream-end-inner">
+    <span class="spinner" title="Loading..."></span>
+  </div>
+</div>
+
+  </div>
+</div>
+<div class="stream-fail-container">
+    <div class="js-stream-whale-end stream-whale-end stream-placeholder centered-placeholder">
+  <div class="stream-end-inner">
+    <h2 class="title">Loading seems to be taking a while.</h2>
+    <p>
+      Twitter may be over capacity or experiencing a momentary hiccup. <a role="button" href="#" class="try-again-after-whale">Try again</a> or visit <a target="_blank" href="http://status.twitter.com">Twitter Status</a> for more information.
+    </p>
+  </div>
+</div>
+</div>
+
+      <ol class="hidden-replies-container"></ol>
+    </div>
+  </div>
+
+    </div>
+
+
+              </div>
+
+
+                  <div class="Grid-cell u-size1of3">
+                    <div class="Grid Grid--withGutter">
+                      <div class="Grid-cell">
+                        <div class="ProfileSidebar ProfileSidebar--withRightAlignment">
+                          <div class="MoveableModule">
+                            
+<div class="SidebarCommonModules">
+
+
+      <div class="SignupCallOut js-signup-call-out
+  
+  
+   SignupCallOut--fastSignup">
+  <div class="SignupCallOut-header">
+    <h3 class="SignupCallOut-title u-textBreak">
+        
+  New to Twitter?
+
+    </h3>
+  </div>
+    <div class="SignupCallOut-subheader">
+      Sign up now to get your own personalized timeline!
+    </div>
+    <div class="signup SignupForm
+    ">
+    <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn primary-btn"
+    data-component="signup_callout"
+    data-element="form"
+    >Sign up</a>
+  </div>
+
+</div>
+
+
+      <div class="RelatedUsers u-hidden">
+  <div class="RelatedUsers-header">
+    <h3 class="RelatedUsers-title">You may also like</h3>
+    &middot;
+    <button class="btn-link js-refresh-related-users" type="button">Refresh</button>
+  </div>
+
+  <div class="RelatedUsers-users">
+  </div>
+</div>
+
+
+
+    <div class="Trends module trends hidden
+            
+            ">
+  <div class="trends-inner">
+    <div class="flex-module trends-container ">
+  <div class="flex-module-header">
+    
+    <h3><span class="trend-location js-trend-location">San Francisco, CA</span></h3>
+  </div>
+  <div class="flex-module-inner">
+    <ul class="trend-items js-trends">
+    </ul>
+  </div>
+</div>
+  </div>
+</div>
+
+
+  <div class="Footer module roaming-module
+            Footer--slim
+            Footer--blankBackground">
+  <div class="flex-module">
+    <div class="flex-module-inner js-items-container">
+      <ul class="u-cf">
+        <li class="Footer-item Footer-copyright copyright">&copy; 2016 Twitter</li>
+        <li class="Footer-item"><a class="Footer-link" href="/about">About</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com">Help</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="/tos">Terms</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="/privacy">Privacy</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514">Cookies</a></li>
+        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170451">Ads info</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+</div>
+
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+  <div id="trends_dialog" class="trends-dialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+          <h3 class="modal-title">
+            
+            Choose a trend location
+          </h3>
+      </div>
+
+      <div class="modal-body">
+
+
+        <div class="trends-dialog-error">
+          <p></p>
+        </div>
+
+        <div class="trends-wrapper" id="trends_dialog_content">
+          
+          <div class="loading">
+            <span class="spinner-bigger"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+          </div>
+        </div>
+      
+    </div>
+    <div class="alert-messages hidden" id="message-drawer">
+    <div class="message ">
+  <div class="message-inside">
+    <span class="message-text"></span>
+      <a role="button" class="Icon Icon--close Icon--medium dismiss" href="#">
+        <span class="visuallyhidden">Dismiss</span>
+      </a>
+  </div>
+</div>
+</div>
+
+    
+
+
+<div class="gallery-overlay"></div>
+<div class="Gallery">
+  <div class="Gallery-closeTarget"></div>
+  <div class="Gallery-content">
+    <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+    <div class="Gallery-media"></div>
+    <div class="GalleryNav GalleryNav--prev">
+      <span class="GalleryNav-handle GalleryNav-handle--prev">
+        <span class="Icon Icon--caretLeft Icon--large">
+          <span class="u-hiddenVisually">
+            Previous
+          </span>
+        </span>
+      </span>
+    </div>
+    <div class="GalleryNav GalleryNav--next">
+      <span class="GalleryNav-handle GalleryNav-handle--next">
+        <span class="Icon Icon--caretRight Icon--large">
+          <span class="u-hiddenVisually">
+            Next
+          </span>
+        </span>
+      </span>
+    </div>
+    <div class="GalleryTweet"></div>
+  </div>
+</div>
+
+
+
+<div class="modal-overlay"></div>
+
+<div id="profile-hover-container"></div>
+
+
+
+<div id="goto-user-dialog" class="modal-container">
+  <div class="modal modal-small draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Go to a person's profile</h3>
+      </div>
+
+      <div class="modal-body">
+        <div class="modal-inner">
+          <form class="t1-form goto-user-form">
+            <input class="input-block username-input" type="text" placeholder="Start typing a name to jump to a profile" aria-label="User">
+            
+
+
+<div role="listbox" class="dropdown-menu typeahead">
+  <div aria-hidden="true" class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <div role="presentation" class="dropdown-inner js-typeahead-results">
+    <div role="presentation" class="typeahead-saved-searches">
+  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
+  <ul role="presentation" class="typeahead-items saved-searches-list">
+    
+    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
+      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
+      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+
+    <ul role="presentation" class="typeahead-items typeahead-topics">
+  
+  <li role="presentation" class="typeahead-item typeahead-topic-item">
+    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
+  </li>
+</ul>
+    
+
+
+<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+  
+  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+    
+    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+      <img class="avatar size32" alt="">
+      <span class="typeahead-user-item-info">
+        <span class="fullname"></span>
+        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+        <span class="username"><s>@</s><b></b></span>
+      </span>
+    </a>
+  </li>
+  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
+</ul>
+
+    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
+  
+  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
+</ul>
+    <div role="presentation" class="typeahead-user-select">
+  <div role="presentation" class="typeahead-empty-suggestions">
+    Suggested users
+  </div>
+  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-selected-end"></li>
+  </ul>
+
+  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-accounts-end"></li>
+  </ul>
+</div>
+
+    <div role="presentation" class="typeahead-dm-conversations">
+  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
+    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
+      <a role="option" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+  </div>
+</div>
+
+          </form>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+  <div id="retweet-tweet-dialog" class="RetweetDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="RetweetDialog-modal modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Retweet this to your followers?</h3>
+      </div>
+
+      <form class="t1-form tweet-form condensed RetweetDialog-tweetForm isWithoutComment" data-condensed-text="Add a comment...">
+        <div class="RetweetDialog-commentBox">
+          <span class="visuallyhidden" id="-label">Optional comment for Retweet</span>
+          <div class="tweet-content">
+            <div class="RichEditor">
+  
+  <div class="RichEditor-mozillaCursorWorkaround">&nbsp;</div>
+  <div class="RichEditor-scrollContainer">
+
+
+
+            <div aria-labelledby="-label" id="" class="tweet-box rich-editor"
+              contenteditable="true" spellcheck="true" role="textbox" aria-multiline="true"></div>
+            
+    <div class="RichEditor-pictographs" aria-hidden="true"></div>
+  </div>
+  <div class="RichEditor-mozillaCursorWorkaround">&nbsp;</div>
+</div>
+
+          </div>
+          
+
+
+<div role="listbox" class="dropdown-menu typeahead">
+  <div aria-hidden="true" class="dropdown-caret">
+    <div class="caret-outer"></div>
+    <div class="caret-inner"></div>
+  </div>
+  <div role="presentation" class="dropdown-inner js-typeahead-results">
+    <div role="presentation" class="typeahead-saved-searches">
+  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
+  <ul role="presentation" class="typeahead-items saved-searches-list">
+    
+    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
+      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
+      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+
+    <ul role="presentation" class="typeahead-items typeahead-topics">
+  
+  <li role="presentation" class="typeahead-item typeahead-topic-item">
+    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
+  </li>
+</ul>
+    
+
+
+<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+  
+  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+    
+    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+      <img class="avatar size32" alt="">
+      <span class="typeahead-user-item-info">
+        <span class="fullname"></span>
+        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+        <span class="username"><s>@</s><b></b></span>
+      </span>
+    </a>
+  </li>
+  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
+</ul>
+
+    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
+  
+  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
+</ul>
+    <div role="presentation" class="typeahead-user-select">
+  <div role="presentation" class="typeahead-empty-suggestions">
+    Suggested users
+  </div>
+  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-selected-end"></li>
+  </ul>
+
+  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
+    
+    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
+      
+      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
+        <img class="avatar size32" alt="">
+        <span class="typeahead-user-item-info">
+          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
+          <span class="select-status select-disabled Icon Icon--unfollow"></span>
+          <span class="fullname"></span>
+          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
+  <span class="u-hiddenVisually">Verified account</span>
+</span></span>
+          <span class="username"><s>@</s><b></b></span>
+        </span>
+      </a>
+    </li>
+    <li role="presentation" class="typeahead-accounts-end"></li>
+  </ul>
+</div>
+
+    <div role="presentation" class="typeahead-dm-conversations">
+  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
+    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
+      <a role="option" tabindex="-1"></a>
+    </li>
+  </ul>
+</div>
+  </div>
+</div>
+
+        </div>
+
+        <div class="RetweetDialog-footer u-cf">
+          <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+          <div class="RetweetDialog-tweet modal-body modal-tweet tweet"></div>
+          <div class="tweet-button">
+            <span class="spinner"></span>
+            <span class="RetweetDialog-counter tweet-counter">140</span>
+            <button class="btn primary-btn retweet-action" type="button">
+              <span class="RetweetDialog-retweetActionLabel">
+                <span class="Icon Icon--retweet"></span>
+                Retweet
+              </span>
+              <span class="RetweetDialog-tweetActionLabel">
+                <span class="Icon Icon--tweet"></span>
+                Tweet
+              </span>
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+  <div id="delete-tweet-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Are you sure you want to delete this Tweet?</h3>
+      </div>
+
+      <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+      <div class="modal-body modal-tweet"></div>
+
+      <div class="modal-footer">
+        <button class="btn cancel-action js-close">Cancel</button>
+        <button class="btn primary-btn delete-action">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="quick-promote-dialog" class="QuickPromoteDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Promote this Tweet</h3>
+      </div>
+      <div class="modal-body">
+        <div class="quick-promote-view-container">
+          <div class="media">
+            <iframe
+              class="quick-promote-iframe js-initial-focus"
+              scrolling="no"
+              frameborder="0"
+              src="">
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div id="block-user-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title">Block</h3>
+      </div>
+
+      <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+      <div class="modal-body modal-tweet"></div>
+
+      <div class="modal-footer">
+        <button class="btn cancel-action js-close">Cancel</button>
+        <button class="btn primary-btn block-action">Block</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+  
+  
+
+     <div id="geo-disabled-dropdown">
+      <div tabindex="-1">
+  <div class="dropdown-caret">
+    <span class="caret-outer"></span>
+    <span class="caret-inner"></span>
+  </div>
+  <ul>
+    <li class="geo-not-enabled-yet">
+      <h2>Add a location to your Tweets</h2>
+      <p>
+        When you tweet with a location, Twitter stores that location.&#32;
+        You can switch location on/off before each Tweet and always have the option to delete your location history.
+        <a href="http://support.twitter.com/forums/26810/entries/78525" target="_blank">Learn more</a>
+      </p>
+      <div>
+        <button type="button" class="geo-turn-on btn primary-btn">Turn location on</button>
+        <button type="button" class="geo-not-now btn-link">Not now</button>
+      </div>
+    </li>
+  </ul>
+</div>
+
+    </div>
+
+  <div id="geo-enabled-dropdown">
+    <div tabindex="-1">
+  <div class="dropdown-caret">
+    <span class="caret-outer"></span>
+    <span class="caret-inner"></span>
+  </div>
+  <div>
+    <div class="geo-query-location">
+      <input class="GeoSearch-queryInput" type="text" autocomplete="off" placeholder="Search for a neighborhood or city">
+      <span class="icon generic-search"></span>
+    </div>
+    <div class="geo-dropdown-status"></div>
+    <ul class="GeoSearch-dropdownMenu"></ul>
+  </div>
+</div>
+
+  </div>
+
+
+  <div id="profile_popup" class="modal-container ProfilePopupContainer--bellbird">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-small draggable">
+    <div class="modal-content clearfix">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Profile summary</h3>
+      </div>
+
+      <div class="modal-body profile-modal">
+
+      </div>
+
+      <div class="loading">
+        <span class="spinner-bigger"></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="list-membership-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-small draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Your lists</h3>
+      </div>
+      <div class="modal-body">
+        <div class="list-membership-content"></div>
+        <span class="spinner lists-spinner" title="Loading&hellip;"></span>
+      </div>
+    </div>
+  </div>
+</div>
+  <div id="list-operations-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Create a new list</h3>
+      </div>
+      <div class="modal-body">
+        
+<div class="list-editor">
+  <div class="field">
+    <label class="t1-label" for="list-name">List name</label>
+    <input id="list-name" type="text" class="text" name="name" value="" />
+  </div>
+  <hr/>
+
+  <div class="field">
+    <label class="t1-label" for="list-description">Description</label>
+    <textarea id="list-description" name="description"></textarea>
+    <span class="help-text">Under 100 characters, optional</span>
+  </div>
+  <hr/>
+
+  <fieldset class="field">
+    <legend class="t1-legend">Privacy</legend>
+    <div class="options">
+      <label class="t1-label" for="list-public-radio">
+        <input class="radio" type="radio" name="mode" id="list-public-radio" value="public" checked="checked"  />
+        <b>Public</b> &middot; Anyone can follow this list
+      </label>
+      <label class="t1-label" for="list-private-radio">
+        <input class="radio" type="radio" name="mode" id="list-private-radio" value="private"  />
+        <b>Private</b> &middot; Only you can access this list
+      </label>
+    </div>
+  </fieldset>
+  <hr/>
+
+  <div class="list-editor-save">
+    <button type="button" class="btn btn-primary update-list-button" data-list-id="">Save list</button>
+  </div>
+
+</div>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="activity-popup-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content clearfix">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+
+      <div class="modal-header">
+        <h3 class="modal-title"></h3>
+      </div>
+
+      <div class="modal-body">
+        <div class="tweet-loading">
+  <div class="spinner-bigger"></div>
+</div>
+
+        <div class="activity-tweet modal-tweet clearfix"></div>
+        <div class="loading">
+          <span class="spinner-bigger"></span>
+        </div>
+        <div class="activity-content clearfix"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+  <div id="copy-link-to-tweet-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Copy link to Tweet</h3>
+      </div>
+      <div class="modal-body">
+        <div class="copy-link-to-tweet-container">
+          <p class="copy-link-to-tweet-instructions">The URL of this tweet is below. Copy it to easily share with friends.</p>
+          <textarea class="link-to-tweet-destination js-initial-focus u-dir" dir="ltr" readonly></textarea>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div id="embed-tweet-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title embed-tweet-title">Embed this Tweet</h3>
+        <h3 class="modal-title embed-video-title">Embed this Video</h3>
+      </div>
+      <div class="modal-body">
+        <div class="embed-code-container">
+  <p class="embed-tweet-instructions">Add this Tweet to your website by copying the code below. <a href="//dev.twitter.com/docs/embedded-tweets">Learn more</a></p>
+  <p class="embed-video-instructions">Add this video to your website by copying the code below. <a href="//dev.twitter.com/docs/embedded-tweets">Learn more</a></p>
+  <form class="t1-form">
+
+    <div class="embed-destination-wrapper">
+      <div class="embed-overlay embed-overlay-spinner"><div class="embed-overlay-content"></div></div>
+      <div class="embed-overlay embed-overlay-error">
+        <p class="embed-overlay-content">Hmm, there was a problem reaching the server. <button type="button" class="btn-link retry-embed">Try again?</button></p>
+      </div>
+      <textarea class="embed-destination js-initial-focus"></textarea>
+      <div class="embed-options">
+        <div class="embed-include-parent-tweet">
+          <label class="t1-label" for="include-parent-tweet">
+            <input type="checkbox" id="include-parent-tweet" class="include-parent-tweet" checked>
+            Include parent Tweet
+          </label>
+        </div>
+        <div class="embed-include-card">
+          <label class="t1-label" for="include-card">
+            <input type="checkbox" id="include-card" class="include-card" checked>
+            Include media
+          </label>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div class="embed-preview">
+    <h3>Preview</h3>
+  </div>
+</div>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+  <div id="login-dialog" class="LoginDialog modal-container u-textCenter">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-large draggable">
+    <div class="LoginDialog-content modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Log in to Twitter</h3>
+      </div>
+      <div class="LoginDialog-body modal-body">
+        <div class="LoginDialog-bird">
+          <span class="Icon Icon--bird Icon--large"></span>
+        </div>
+        <div class="LoginDialog-form">
+<form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
+  data-component="dialog"
+  data-element="login"
+>
+  <div class="LoginForm-input LoginForm-username">
+    <input
+      type="text"
+      class="text-input email-input js-signin-email"
+      name="session[username_or_email]"
+      autocomplete="username"
+      placeholder="Phone, email or username"
+    />
+  </div>
+
+  <div class="LoginForm-input LoginForm-password">
+    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
+  </div>
+
+  <div class="LoginForm-rememberForgot">
+    <label>
+      <input type="checkbox" value="1" name="remember_me" checked="checked">
+      <span>Remember me</span>
+    </label>
+    <span class="separator">&middot;</span>
+    <a class="forgot" href="/account/begin_password_reset">Forgot password?</a>
+  </div>
+
+  <input type="submit" class="submit btn primary-btn js-submit" value="Log in">
+
+    <input type="hidden" name="return_to_ssl" value="true">
+
+  <input type="hidden" name="scribe_log">
+  <input type="hidden" name="redirect_after_login" value="/github">
+  <input type="hidden" value="0ff51e342cbaed52729adbdd37fcab367da1e38f" name="authenticity_token">
+</form>
+        </div>
+      </div>
+      <div class="LoginDialog-footer modal-footer u-textCenter">
+        Don't have an account? <a class="LoginDialog-signupLink" href="https://twitter.com/signup">Sign up &raquo;</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="signup-dialog" class="SignupDialog modal-container u-textCenter">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-large draggable">
+    <div class="SignupDialog-content modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Sign up for Twitter</h3>
+      </div>
+      <div class="SignupDialog-body modal-body">
+        <div class="SignupDialog-icon">
+          <span class="Icon Icon--bird Icon--extraLarge"></span>
+        </div>
+        <h2 class="SignupDialog-heading">Not on Twitter? Sign up, tune into the things you care about, and get updates as they happen.</h2>
+        <div class="SignupDialog-form">
+  <div class="signup SignupForm
+    ">
+    <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn primary-btn"
+    data-component="dialog"
+    data-element="signup"
+    >Sign up</a>
+  </div>
+        </div>
+      </div>
+      <div class="SignupDialog-footer modal-footer u-textCenter">
+        Have an account? <a class="SignupDialog-signinLink" href="/login">Log in &raquo;</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <div id="sms-codes-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal modal-medium draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Two-way (sending and receiving) short codes:</h3>
+      </div>
+      <div class="modal-body">
+        
+<table id="sms_codes" cellpadding="0" cellspacing="0">
+  <thead>
+    <tr>
+      <th>Country</th>
+      <th>Code</th>
+      <th>For customers of</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>United States</td>
+      <td>40404</td>
+      <td>(any)</td>
+    </tr>
+    <tr>
+      <td>Canada</td>
+      <td>21212</td>
+      <td>(any)</td>
+    </tr>
+    <tr>
+      <td>United Kingdom</td>
+      <td>86444</td>
+      <td>Vodafone, Orange, 3, O2</td>
+    </tr>
+    <tr>
+      <td>Brazil</td>
+      <td>40404</td>
+      <td>Nextel, TIM</td>
+    </tr>
+    <tr>
+      <td>Haiti</td>
+      <td>40404</td>
+      <td>Digicel, Voila</td>
+    </tr>
+    <tr>
+      <td>Ireland</td>
+      <td>51210</td>
+      <td>Vodafone, O2</td>
+    </tr>
+    <tr>
+      <td>India</td>
+      <td>53000</td>
+      <td>Bharti Airtel, Videocon, Reliance</td>
+    </tr>
+    <tr>
+      <td>Indonesia</td>
+      <td>89887</td>
+      <td>AXIS, 3, Telkomsel, Indosat, XL Axiata</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Italy</td>
+      <td>4880804</td>
+      <td>Wind</td>
+    </tr>
+    <tr>
+      <td>3424486444</td>
+      <td>Vodafone</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="3">
+        &raquo; <a class="js-initial-focus" target="_blank" href="http://support.twitter.com/articles/14226-how-to-find-your-twitter-short-code-or-long-code">See SMS short codes for other countries</a>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="leadgen-confirm-dialog" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--medium">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Confirmation</h3>
+      </div>
+      <div class="modal-body">
+        <div class="leadgen-card-container">
+          <div class="media">
+            <iframe
+              class="cards2-promotion-iframe"
+              scrolling="no"
+              frameborder="0"
+              src="">
+            </iframe>
+          </div>
+        </div>
+        <div class="js-macaw-cards-iframe-container" data-card-name="promotion">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div id="auth-webview-dialog" class="AuthWebViewDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">&nbsp;</h3>
+      </div>
+      <div class="modal-body">
+        <div class="auth-webview-view-container">
+          <div class="media">
+            <iframe
+              class="auth-webview-card-iframe js-initial-focus"
+              scrolling="no"
+              frameborder="0"
+              width="590px"
+              height="500px"
+              src="">
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<div id="promptbird-modal-prompt" class="modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal">
+    
+    <button type="button" class="modal-btn js-promptDismiss modal-close js-close">
+      <span class="Icon Icon--close Icon--medium">
+        <span class="visuallyhidden">Close</span>
+      </span>
+    </button>
+    <div class="modal-content"></div>
+  </div>
+</div>
+
+
+   <div id="payment-order-detail-dialog" class="PaymentOrderDialog modal-container">
+  <div class="close-modal-background-target"></div>
+  <div class="modal draggable">
+    <div class="modal-content">
+      <button type="button" class="modal-btn modal-close js-close">
+  <span class="Icon Icon--close Icon--large">
+    <span class="visuallyhidden">Close</span>
+  </span>
+</button>
+
+      <div class="modal-header">
+        <h3 class="modal-title">Buy Now</h3>
+      </div>
+      <div class="modal-body">
+        <div class="alert">
+          <h4>Hmm... Something went wrong. Please try again.</h4>
+        </div>
+        <div class="spinner-bigger"></div>
+        <div class="PaymentOrderDialog-orderDetails"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+
+<div id="create-custom-timeline-dialog" class="modal-container"></div>
+<div id="edit-custom-timeline-dialog" class="modal-container"></div>
+<div id="curate-dialog" class="modal-container"></div>
+<div id="media-edit-dialog" class="modal-container"></div>
+
+
+      <div class="PermalinkOverlay PermalinkOverlay-with-background " id="permalink-overlay">
+  <button class="PermalinkOverlay-next PermalinkOverlay-button u-posFixed js-next" type="button">
+    <span class="Icon Icon--caretLeft Icon--large"></span>
+    <span class="u-hiddenVisually">Next Tweet from user</span>
+  </button>
+  <div class="PermalinkOverlay-modal">
+    <div class="PermalinkOverlay-spinnerContainer u-hidden">
+      <div class="PermalinkOverlay-spinner"></div>
+    </div>
+    <div class="PermalinkOverlay-content">
+      <div class="PermalinkOverlay-body"
+>
+      </div>
+    </div>
+  </div>
+</div>
+
+    <div class="hidden" id="hidden-content">
+  <iframe aria-hidden="true" class="tweet-post-iframe" name="tweet-post-iframe"></iframe>
+  <iframe aria-hidden="true" class="dm-post-iframe" name="dm-post-iframe"></iframe>
+
+</div>
+
+    
+    <div id="spoonbill-outer"></div>
+  </body>
+</html>

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -138,6 +138,9 @@ describe 'watch-web-resources', ->
       nock(/.*/).get(/.*/).reply(404)
       @room.user.say 'pchaigno', 'hubot: did any web resource change?'
 
+    afterEach ->
+      nock.cleanAll()
+
     it 'answers that nothing changed', ->
       expect(nock.isDone()).to.be.false
       expect(nock.pendingMocks()).to.eql ['GET /.*///.*/']


### PR DESCRIPTION
Follow up to #12.
In `watch-web-resources.coffee`, a hash is computed to keep track of web resource changes.
This pull request changes the default behavior for `text/html` resources: the text extracted from the HTML (with `html-ot-text`) is now hashed instead of the HTML itself.

This should make it possible to watch HTML resources without having a new alert every 10 seconds.
If this is not sufficient in practice, a fuzzy hash might be needed.