### PR TITLE
Watch web resources using fuzzy hashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "5.6.0"
   - "5.5.0"
   - "4.3.1"
+before_install:
+  - sudo apt-get install -y libfuzzy-dev
 install:
   - npm install
   - npm install coffee-coverage istanbul coveralls

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "mocha --compilers coffee:coffee-script/register tests"
   },
   "dependencies": {
-    "crypto": "0.0.3",
     "fs": "0.0.2",
     "html-to-text": "^2.1.0",
     "hubot": ">= 2.6.0",
@@ -28,7 +27,8 @@
     "hubot-url-title": "^1.3",
     "hubot-wikipedia": "0.0.2",
     "optparse": "1.0.3",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "ssdeep": "^0.1.1"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/scripts/hash-web-resources.coffee
+++ b/scripts/hash-web-resources.coffee
@@ -1,4 +1,4 @@
-crypto = require 'crypto'
+ssdeep = require 'ssdeep'
 htmlToText = require 'html-to-text'
 fs = require 'fs'
 
@@ -9,5 +9,5 @@ module.exports = {
   computeHash: (body, contentType) ->
     if contentType and /text\/html/.test(contentType)
       body = extractText(body)
-    return crypto.createHash("sha256").update(body).digest("base64")
+    return ssdeep.hash(body)
 }

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -37,7 +37,9 @@ changedWebResource = (robot, room, resource, hash) ->
         newHash = 0
       else if response.statusCode is 200
         newHash = hasher.computeHash body, response.headers['content-type']
-        score = ssdeep.compare(newHash, hash)
+        score = 0
+        if typeof hash is 'string'
+          score = ssdeep.compare(newHash, hash)
         threshold = process.env.HUBOT_WATCH_THRESHOLD
         if score > threshold
           newHash = null

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -86,6 +86,12 @@ module.exports = (robot) ->
   robot.brain.on 'loaded', (_) ->
     init(robot)
 
+  robot.respond /reload/i, (res) ->
+    if periodicCheckId isnt null
+      clearInterval(periodicCheckId)
+      periodicCheckId = null
+      firstPeriodicCheck = true
+
   robot.respond /watch ((?:https?:\/\/)?([^\s]+))$/, (res) ->
     resource = res.match[1]
     if not /^https?:\/\//.test(resource)

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -92,7 +92,7 @@ module.exports = (robot) ->
         res.reply "Are you sure about that url?"
         res.send "#{err}"
       else if response.statusCode is 200
-        hash = hasher.computeHash(body)
+        hash = hasher.computeHash body, response.headers['content-type']
         resources = robot.brain.get('web_resources') or {}
         resources[res.match[2]] = hash
         robot.brain.set 'web_resources', resources

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -17,6 +17,7 @@
 
 request = require "request"
 hasher = require './hash-web-resources.coffee'
+ssdeep = require 'ssdeep'
 
 PERIODIC_CHECKS_INTERVAL = 60000
 MAX_SIZE_DOWNLOADED_FILES = 1000000
@@ -36,7 +37,9 @@ changedWebResource = (robot, room, resource, hash) ->
         newHash = 0
       else if response.statusCode is 200
         newHash = hasher.computeHash body, response.headers['content-type']
-        if newHash is hash
+        score = ssdeep.compare(newHash, hash)
+        threshold = process.env.HUBOT_WATCH_THRESHOLD
+        if score > threshold
           newHash = null
       else
         newHash = response.statusCode

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -18,7 +18,7 @@
 request = require "request"
 hasher = require './hash-web-resources.coffee'
 
-PERIODIC_CHECKS_INTERVAL = 10000
+PERIODIC_CHECKS_INTERVAL = 60000
 MAX_SIZE_DOWNLOADED_FILES = 1000000
 periodicCheckId = null
 firstPeriodicCheck = true

--- a/scripts/watch-web-resources.coffee
+++ b/scripts/watch-web-resources.coffee
@@ -98,7 +98,7 @@ module.exports = (robot) ->
         robot.brain.set 'web_resources', resources
         if firstPeriodicCheck
           room = res.envelope.room
-          if room is null
+          if typeof room is "undefined"
           # Direct message, we need to find the room where we last saw the user.
             room = robot.brain.userForName(res.message.user.name).room
           robot.brain.set 'room_web_resources', room

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -12,6 +12,7 @@ describe 'watch-web-resources', ->
 
   beforeEach ->
     @room = helper.createRoom(httpd: false)
+    process.env.HUBOT_WATCH_THRESHOLD = 90
 
   context 'pchaigno wants to monitor a new web resource', ->
     beforeEach ->

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -14,6 +14,10 @@ describe 'watch-web-resources', ->
     @room = helper.createRoom(httpd: false)
     process.env.HUBOT_WATCH_THRESHOLD = 90
 
+  afterEach ->
+    @room.user.say 'pchaigno', 'hubot: reload'
+
+
   context 'pchaigno wants to monitor a new web resource', ->
     beforeEach ->
       nock('https://github.com').get('/').reply(200, 'github page')

--- a/tests/watch-web-resources.coffee
+++ b/tests/watch-web-resources.coffee
@@ -140,6 +140,23 @@ describe 'watch-web-resources', ->
       expect(@room.robot.brain.get('web_resources')['github.com']).to.not.eql ''
 
 
+  context 'pchaigno asks if any web resource changed after a server-side error', ->
+    beforeEach ->
+      @room.robot.brain.set 'web_resources', {'github.com': '502'}
+      nock('http://github.com').get('/').reply(200, 'github page')
+      co =>
+        @room.user.say 'pchaigno', 'hubot: did any web resource change?'
+        new Promise.delay 100
+
+    it 'answers with the url of the changed resources', ->
+      expect(nock.isDone()).to.be.true
+      expect(@room.messages).to.eql [
+        ['pchaigno', 'hubot: did any web resource change?']
+        ['hubot', "github.com changed"]
+      ]
+      expect(@room.robot.brain.get('web_resources')['github.com']).to.not.eql '502'
+
+
   context 'pchaigno asks if any web resource changed', ->
     beforeEach ->
       nock(/.*/).get(/.*/).reply(404)


### PR DESCRIPTION
Watches web resources using fuzzy ssdeep hashes instead of common hashes. Hashes are computed on the text extracted from the HTML (when the resource is of HTML type). Hashes are compared using the ssdeep comparison with a threshold set via the `HUBOT_WATCH_THRESHOLD` environment variable.

Also fixes various issues with the periodic checks. There's still an issue when reloading scripts.