### PR TITLE
Fix Travis CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
   - "5.6.0"
   - "5.5.0"
   - "4.3.1"
-before_install:
-  - sudo apt-get install -y libfuzzy-dev
 install:
   - npm install
   - npm install coffee-coverage istanbul coveralls
@@ -21,4 +19,5 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+      - libfuzzy-dev
 


### PR DESCRIPTION
This pull request fixes the Travis CI error by dropping the requirement for privileges.
The libfuzzy-dev package was whitelisted for Travis CI in travis-ci/apt-package-whitelist#3120.

Note: This should also slightly speed up the builds as they now run in containers.